### PR TITLE
Fix parameter name in AllOurIdeasConnector

### DIFF
--- a/agents/src/connectors/collaboration/allOurIdeasConnector.ts
+++ b/agents/src/connectors/collaboration/allOurIdeasConnector.ts
@@ -161,7 +161,7 @@ export class PsAllOurIdeasConnector extends PsBaseVotingCollaborationConnector {
     }
   }
 
-  async postItems(groupId: number, itesm: []): Promise<boolean> {
+  async postItems(groupId: number, items: []): Promise<boolean> {
     //TODO
     return false;
   }


### PR DESCRIPTION
## Summary
- rename `itesm` to `items` in `postItems` method

## Testing
- `git status --short`