### PR TITLE
Add license education comparison agents

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/compareLicenseEducationAgent.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/compareLicenseEducationAgent.ts
@@ -1,0 +1,133 @@
+import { PolicySynthAgent } from "@policysynth/agents/base/agent.js";
+import { PsAgent } from "@policysynth/agents/dbModels/agent.js";
+import { PsAiModelType, PsAiModelSize } from "@policysynth/agents/aiModelTypes.js";
+import stringSimilarity from "string-similarity";
+import { SheetsLicenseEducationImportAgent } from "./imports/sheetsLicenseEducationImport.js";
+import { PsAgentClassCategories } from "@policysynth/agents/agentCategories.js";
+import type { PsAgentClassCreationAttributes } from "@policysynth/agents/dbModels/agentClass.js";
+
+/**
+ * Agent that compares license education requirements across two worksheets.
+ *
+ * Configure **two** Google Sheet connectors ("Sheet1" and "Sheet2") in the
+ * Policy Synth UI, or point a single connector at different worksheets.  The
+ * optional `memory.sheet1Name` and `memory.sheet2Name` values allow overriding
+ * the worksheet/tab names.  Results may be exported to another worksheet using
+ * {@link SheetsLicenseEducationExportAgent}.  Set the output sheet name when
+ * constructing that exporter or via its own memory field.
+ */
+export class CompareLicenseEducationAgent extends PolicySynthAgent {
+  declare memory: LicenseEducationComparisonMemory;
+
+  private static readonly CLASS_BASE_ID = "c9d62559-education-compare";
+  private static readonly CLASS_VERSION = 1;
+
+  static getAgentClass(): PsAgentClassCreationAttributes {
+    return {
+      class_base_id: this.CLASS_BASE_ID,
+      user_id: 0,
+      name: "License Education Comparison Agent",
+      version: this.CLASS_VERSION,
+      available: true,
+      configuration: {
+        category: PsAgentClassCategories.DataAnalysis,
+        subCategory: "licenseEducationComparison",
+        hasPublicAccess: false,
+        description:
+          "Compares license education requirements across two sheets",
+        queueName: "LICENSE_EDUCATION_COMPARISON",
+      },
+    };
+  }
+
+  /**
+   * Entry point used by the queue processor.  You may optionally set
+   * `memory.sheet1Name` and `memory.sheet2Name` to override the worksheet
+   * names used for input.
+   */
+  async process(): Promise<void> {
+    const sheet1 = (this.memory as any).sheet1Name ?? "Sheet1";
+    const sheet2 = (this.memory as any).sheet2Name ?? "Sheet2";
+    await this.compare(sheet1, sheet2);
+  }
+
+  async compare(sheet1Name = "Sheet1", sheet2Name = "Sheet2"): Promise<void> {
+    const importer1 = new SheetsLicenseEducationImportAgent(
+      this.agent,
+      this.memory,
+      0,
+      10,
+      sheet1Name
+    );
+    const importer2 = new SheetsLicenseEducationImportAgent(
+      this.agent,
+      this.memory,
+      10,
+      20,
+      sheet2Name
+    );
+
+    const sheet1Rows = await importer1.importRows();
+    const sheet2Rows = await importer2.importRows();
+
+    this.memory.sheet1Rows = sheet1Rows;
+    this.memory.sheet2Rows = sheet2Rows;
+    this.memory.comparisons = [];
+
+    for (const row1 of sheet1Rows) {
+      const candidates = this.selectCandidates(row1, sheet2Rows);
+      const comparison = await this.compareRowWithCandidates(row1, candidates);
+      this.memory.comparisons.push(comparison);
+    }
+  }
+
+  /** Find sheet2 rows with fuzzy match on licenseType */
+  private selectCandidates(
+    row: LicenseEducationRow,
+    sheet2: LicenseEducationRow[]
+  ): LicenseEducationRow[] {
+    if (!sheet2.length) return [];
+    const scores = sheet2.map((r) => ({
+      row: r,
+      rating: stringSimilarity.compareTwoStrings(
+        (row.licenseType || "").toLowerCase(),
+        (r.licenseType || "").toLowerCase()
+      ),
+    }));
+    const threshold = 0.6;
+    return scores
+      .filter((s) => s.rating >= threshold)
+      .sort((a, b) => b.rating - a.rating)
+      .slice(0, 5)
+      .map((s) => s.row);
+  }
+
+  private async compareRowWithCandidates(
+    row1: LicenseEducationRow,
+    candidates: LicenseEducationRow[]
+  ): Promise<LicenseEducationComparison> {
+    const systemPrompt = `You are an expert at matching license education requirements.\n` +
+      `We have one row from Sheet1 and several candidate rows from Sheet2.\n` +
+      `Decide if the Sheet1 row matches any candidate.\n` +
+      `Sheet1 Row: ${JSON.stringify(row1)}\n` +
+      `Candidate Rows: ${JSON.stringify(candidates)}\n` +
+      `Respond only with JSON in this format:` +
+      `{"matchedLicenseType2":"","eduReq2":"","matchConfidence":0,"explanation":""}`;
+
+    const messages = [this.createSystemMessage(systemPrompt)];
+    const result = (await this.callModel(
+      PsAiModelType.TextReasoning,
+      PsAiModelSize.Large,
+      messages
+    )) as LicenseEducationComparison;
+
+    return {
+      licenseType1: row1.licenseType,
+      eduReq1: row1.educationRequirement,
+      matchedLicenseType2: result?.matchedLicenseType2,
+      eduReq2: result?.eduReq2,
+      matchConfidence: result?.matchConfidence ?? 0,
+      explanation: result?.explanation ?? "",
+    };
+  }
+}

--- a/projects/skillsFirst/agents/src/jobDescriptions/compareLicenseEducationQueue.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/compareLicenseEducationQueue.ts
@@ -1,0 +1,34 @@
+import { PolicySynthAgentQueue } from "@policysynth/agents/base/agentQueue.js";
+import { CompareLicenseEducationAgent } from "./compareLicenseEducationAgent.js";
+
+export class CompareLicenseEducationQueue extends PolicySynthAgentQueue {
+  declare memory: LicenseEducationComparisonMemory;
+
+  get agentQueueName(): string {
+    return "LICENSE_EDUCATION_COMPARISON";
+  }
+
+  get processors() {
+    return [
+      {
+        processor: CompareLicenseEducationAgent,
+        weight: 100,
+      },
+    ];
+  }
+
+  forceMemoryRestart = false;
+
+  async setupMemoryIfNeeded(agentId: number) {
+    const psAgent = await this.getOrCreatePsAgent(agentId);
+    this.logger.info(`Setting up memory for agent ${psAgent.id}`);
+
+    let agentMemory = this.agentMemoryMap.get(agentId);
+    if (!agentMemory) {
+      agentMemory = { agentId: psAgent.id } as LicenseEducationComparisonMemory;
+      this.agentMemoryMap.set(agentId, agentMemory);
+    } else {
+      this.logger.info(`Memory already set up for agent ${psAgent.id}: `);
+    }
+  }
+}

--- a/projects/skillsFirst/agents/src/jobDescriptions/exports/sheetsLicenseEducationExport.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/exports/sheetsLicenseEducationExport.ts
@@ -1,0 +1,116 @@
+import { PolicySynthAgent } from "@policysynth/agents/base/agent.js";
+import { PsAgent } from "@policysynth/agents/dbModels/agent.js";
+import { PsConnectorFactory } from "@policysynth/agents/connectors/base/connectorFactory.js";
+import { PsConnectorClassTypes } from "@policysynth/agents/connectorTypes.js";
+import { PsBaseSheetConnector } from "@policysynth/agents/connectors/base/baseSheetConnector.js";
+
+/**
+ * Exports {@link LicenseEducationComparison} results to Google Sheets.
+ *
+ * Configure a spreadsheet connector pointing to your output workbook.  The
+ * worksheet/tab name defaults to "Sheet1" but can be supplied to the
+ * constructor or via a memory field when using the runner.
+ */
+export class SheetsLicenseEducationExportAgent extends PolicySynthAgent {
+  declare memory: any;
+
+  private sheetsConnector: PsBaseSheetConnector;
+  private sheetName = "Sheet1";
+  private readonly chunkSize = 500;
+
+  skipAiModels = true;
+
+  constructor(
+    agent: PsAgent,
+    memory: any,
+    startProgress = 0,
+    endProgress = 100,
+    sheetName?: string
+  ) {
+    super(agent, memory, startProgress, endProgress);
+
+    this.sheetsConnector = PsConnectorFactory.getConnector(
+      this.agent,
+      this.memory,
+      PsConnectorClassTypes.Spreadsheet,
+      false
+    ) as PsBaseSheetConnector;
+
+    if (!this.sheetsConnector) {
+      throw new Error("Google Sheets connector not found");
+    }
+    if (sheetName) this.sheetName = sheetName;
+  }
+
+  async exportComparisons(rows: LicenseEducationComparison[]): Promise<void> {
+    await this.updateRangedProgress(0, "Starting License-Education sheet export");
+
+    const data = this.generateSheetData(rows);
+    const sanitized = this.sanitiseData(data);
+    await this.writeInChunks(sanitized);
+
+    await this.updateRangedProgress(100, "Google Sheets export completed");
+  }
+
+  private generateSheetData(rows: LicenseEducationComparison[]): (string | number)[][] {
+    const headers = [
+      "licenseType1",
+      "eduReq1",
+      "matchedLicenseType2",
+      "eduReq2",
+      "matchConfidence",
+      "explanation",
+    ];
+    const sheetRows: (string | number)[][] = [headers, headers];
+
+    for (const r of rows) {
+      sheetRows.push([
+        r.licenseType1,
+        r.eduReq1,
+        r.matchedLicenseType2 ?? "",
+        r.eduReq2 ?? "",
+        r.matchConfidence,
+        r.explanation,
+      ]);
+    }
+    return sheetRows;
+  }
+
+  private async writeInChunks(rows: (string | number)[][]): Promise<void> {
+    if (!rows.length) return;
+    const totalCols = rows[0].length;
+    let pointer = 1;
+
+    for (let i = 0; i < rows.length; i += this.chunkSize) {
+      const chunk = rows.slice(i, i + this.chunkSize);
+      const startRow = pointer;
+      const endRow = pointer + chunk.length - 1;
+      const endColLetter = this.colIdxToLetter(totalCols - 1);
+      const range = `${this.sheetName}!A${startRow}:${endColLetter}${endRow}`;
+
+      await this.sheetsConnector.updateRange(range, chunk as unknown as string[][]);
+      pointer += chunk.length;
+    }
+  }
+
+  private colIdxToLetter(idx: number): string {
+    let temp = idx;
+    let letter = "";
+    while (temp >= 0) {
+      letter = String.fromCharCode((temp % 26) + 65) + letter;
+      temp = Math.floor(temp / 26) - 1;
+    }
+    return letter;
+  }
+
+  private sanitiseData(data: (string | number)[][]): (string | number)[][] {
+    return data.map((row) =>
+      row.map((cell) => {
+        if (cell === undefined || cell === null) return "";
+        if (typeof cell === "number") return cell;
+        if (typeof cell === "object") return JSON.stringify(cell);
+        return String(cell);
+      })
+    );
+  }
+}

--- a/projects/skillsFirst/agents/src/jobDescriptions/imports/sheetsLicenseEducationImport.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/imports/sheetsLicenseEducationImport.ts
@@ -1,0 +1,90 @@
+import { PolicySynthAgent } from "@policysynth/agents/base/agent.js";
+import { PsAgent } from "@policysynth/agents/dbModels/agent.js";
+import { PsConnectorFactory } from "@policysynth/agents/connectors/base/connectorFactory.js";
+import { PsConnectorClassTypes } from "@policysynth/agents/connectorTypes.js";
+import { PsBaseSheetConnector } from "@policysynth/agents/connectors/base/baseSheetConnector.js";
+
+/**
+ * Simplified Google Sheets importer that reads two columns
+ * (license type and education requirement) and returns
+ * an array of {@link LicenseEducationRow}.
+ */
+export class SheetsLicenseEducationImportAgent extends PolicySynthAgent {
+  private sheetsConnector: PsBaseSheetConnector;
+  private sheetName = "Sheet1";
+  private readonly startRow = 1; // header row
+  private readonly maxRows = 1000;
+  private readonly maxCols = 2;
+
+  skipAiModels = true;
+
+  constructor(
+    agent: PsAgent,
+    memory: any,
+    startProgress = 0,
+    endProgress = 100,
+    sheetName?: string
+  ) {
+    super(agent, memory, startProgress, endProgress);
+
+    this.sheetsConnector = PsConnectorFactory.getConnector(
+      this.agent,
+      this.memory,
+      PsConnectorClassTypes.Spreadsheet,
+      true
+    ) as PsBaseSheetConnector;
+
+    if (!this.sheetsConnector) {
+      throw new Error("Google Sheets connector not found");
+    }
+    if (sheetName) this.sheetName = sheetName;
+  }
+
+  /** Reads two columns from the configured worksheet. */
+  async importRows(): Promise<LicenseEducationRow[]> {
+    await this.updateRangedProgress(
+      0,
+      `Starting Google Sheets import: ${this.sheetsConnector.name}`
+    );
+
+    const range = `${this.sheetName}!A${this.startRow}:${this.columnIndexToLetter(
+      this.maxCols - 1
+    )}${this.maxRows}`;
+    const rows = await this.sheetsConnector.getRange(range);
+
+    if (!rows || rows.length < 2) {
+      this.logger.warn(
+        `No data or insufficient rows in sheet: ${this.sheetsConnector.name}`
+      );
+      return [];
+    }
+
+    // Assume first row is header
+    const dataRows = rows.slice(1);
+
+    const results: LicenseEducationRow[] = [];
+    for (const row of dataRows) {
+      const licenseType = (row[0] ?? "").toString().trim();
+      const educationRequirement = (row[1] ?? "").toString().trim();
+      if (!licenseType && !educationRequirement) continue;
+      results.push({ licenseType, educationRequirement });
+    }
+
+    await this.updateRangedProgress(
+      100,
+      `Completed import from ${this.sheetsConnector.name}`
+    );
+    return results;
+  }
+
+  /** 0-based column index → spreadsheet letter */
+  private columnIndexToLetter(index: number): string {
+    let temp = index;
+    let letter = "";
+    while (temp >= 0) {
+      letter = String.fromCharCode((temp % 26) + 65) + letter;
+      temp = Math.floor(temp / 26) - 1;
+    }
+    return letter;
+  }
+}

--- a/projects/skillsFirst/agents/src/jobDescriptions/runAgents.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/runAgents.ts
@@ -13,6 +13,8 @@ import { JobDescriptionRewriterAgent } from "./rewriterAgent.js";
 import { JobDescriptionRewriterQueue } from "./rewriteAgentQueue.js";
 import { JobTitleLicenseDegreeAnalysisQueue } from "./licenceDegrees/licenceAnalysisQueue.js";
 import { JobTitleLicenseDegreeAnalysisAgent } from "./licenceDegrees/licenceAnalysisAgent.js";
+import { CompareLicenseEducationQueue } from "./compareLicenseEducationQueue.js";
+import { CompareLicenseEducationAgent } from "./compareLicenseEducationAgent.js";
 export class JobDescriptionAgentRunner extends PsBaseAgentRunner {
   protected agentClasses: PsAgentClassCreationAttributes[];
   protected connectorClasses: PsAgentConnectorClassCreationAttributes[];
@@ -24,6 +26,7 @@ export class JobDescriptionAgentRunner extends PsBaseAgentRunner {
       new JobDescriptionCompareSheetsQueue(),
       new JobDescriptionRewriterQueue(),
       new JobTitleLicenseDegreeAnalysisQueue(),
+      new CompareLicenseEducationQueue(),
     ];
 
     this.agentClasses = [
@@ -31,6 +34,7 @@ export class JobDescriptionAgentRunner extends PsBaseAgentRunner {
       SheetsComparisonAgent.getAgentClass(),
       JobDescriptionRewriterAgent.getAgentClass(),
       JobTitleLicenseDegreeAnalysisAgent.getAgentClass(),
+      CompareLicenseEducationAgent.getAgentClass(),
     ];
 
     this.connectorClasses = [

--- a/projects/skillsFirst/agents/src/jobDescriptions/types.d.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/types.d.ts
@@ -432,3 +432,23 @@ type DeepResearchWebResearchTypes =
   | "jobDescription"
   | "licenseSource"
   | "organization";
+
+interface LicenseEducationRow {
+  licenseType: string;
+  educationRequirement: string;
+}
+
+interface LicenseEducationComparison {
+  licenseType1: string;
+  eduReq1: string;
+  matchedLicenseType2?: string;
+  eduReq2?: string;
+  matchConfidence: number;
+  explanation: string;
+}
+
+interface LicenseEducationComparisonMemory extends JobDescriptionMemoryData {
+  sheet1Rows: LicenseEducationRow[];
+  sheet2Rows: LicenseEducationRow[];
+  comparisons: LicenseEducationComparison[];
+}


### PR DESCRIPTION
## Summary
- extend job description types with license education interfaces
- add sheet importer/exporter for license education data
- implement comparison agent using fuzzy matching and LLM
- register comparison queue and include in agent runner

## Testing
- `npm run build` *(fails: cannot find module declarations)*