### PR TITLE
Add timeout and retry logic for model calls

### DIFF
--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -27,6 +27,7 @@ interface PsAiModelConfig {
   temperature?: number;
   reasoningEffort?: 'low' | 'medium' | 'high';
   maxThinkingTokens?: number;
+  timeoutMs?: number;
   prices: PsBaseModelPriceConfiguration;
 }
 
@@ -130,6 +131,7 @@ interface PsAiModelConfiguration {
   defaultTemperature: number;
   limitTPM?: number;
   limitRPM?: number;
+  timeoutMs?: number;
 }
 
 // tablename "ps_ai_models"


### PR DESCRIPTION
## Summary
- add `timeoutMs` config option for AI model configuration
- handle `PS_MODEL_CALL_TIMEOUT_MS` env variable with default 10 minutes
- apply local timeout with immediate retry in `agentModelManager`

## Testing
- `npm test --silent` *(fails: gulp not found)*