### PR TITLE
Fix is5xxError check for plain error string

### DIFF
--- a/agents/src/base/agentModelManager.ts
+++ b/agents/src/base/agentModelManager.ts
@@ -560,7 +560,7 @@ export class PsAiModelManager extends PolicySynthAgentBase {
       if (
         (err?.response?.status >= 500 && err?.response?.status < 600) ||
         err?.message?.includes("500 Internal Server Error") ||
-        err?.includes("500 Internal Server Error")
+        (typeof err === "string" && err.includes("500 Internal Server Error"))
       ) {
         this.logDetailedServerError(model, err, messages);
         return true;


### PR DESCRIPTION
## Summary
- handle err being a string in `is5xxError`

## Testing
- `npm run build`