### PR TITLE
Add education requirement deep research agent

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/types.d.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/types.d.ts
@@ -62,6 +62,7 @@ interface JobDescriptionMemoryData extends PsAgentMemoryData {
   rewritingBuckets?: { [bucket: string]: JobDescription[] };
   additionalGeneralContext?: string;
   researchPlan?: string;
+  educationRequirementResearchResults?: import("../legalResearch/types.js").EducationRequirementResearchRow[];
 }
 
 /**

--- a/projects/skillsFirst/agents/src/legalResearch/educationExportSheet.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/educationExportSheet.ts
@@ -1,0 +1,107 @@
+import { PolicySynthAgent } from "@policysynth/agents/base/agent.js";
+import { PsAgent } from "@policysynth/agents/dbModels/agent.js";
+import { PsConnectorFactory } from "@policysynth/agents/connectors/base/connectorFactory.js";
+import { PsConnectorClassTypes } from "@policysynth/agents/connectorTypes.js";
+import { PsBaseSheetConnector } from "@policysynth/agents/connectors/base/baseSheetConnector.js";
+import type { EducationRequirementResearchRow } from "./types.js";
+
+export class SheetsEducationRequirementExportAgent extends PolicySynthAgent {
+  declare memory: any;
+  private sheetsConnector: PsBaseSheetConnector;
+  private sheetName: string;
+  private readonly chunkSize = 500;
+  skipAiModels = true;
+
+  constructor(agent: PsAgent, memory: any, start: number, end: number, sheetName = "Sheet1") {
+    super(agent, memory, start, end);
+    this.sheetName = sheetName;
+    this.sheetsConnector = PsConnectorFactory.getConnector(
+      this.agent,
+      this.memory,
+      PsConnectorClassTypes.Spreadsheet,
+      false
+    ) as PsBaseSheetConnector;
+    if (!this.sheetsConnector) {
+      throw new Error("Google Sheets connector not found");
+    }
+  }
+
+  async processJsonData(rows: EducationRequirementResearchRow[]): Promise<void> {
+    await this.updateRangedProgress(0, "Starting Education Requirement export");
+    const data = this.generateSheetData(rows);
+    const sanitized = this.sanitiseData(data);
+    await this.writeInChunks(sanitized);
+    await this.updateRangedProgress(100, "Google Sheets export completed");
+  }
+
+  private generateSheetData(rows: EducationRequirementResearchRow[]): (string | number)[][] {
+    const headers = [
+      "Job Title",
+      "Source URL",
+      "Requirement Summary",
+      "Reasoning",
+      "Confidence Score",
+      "Elo Rating",
+    ];
+    const shortHeaders = headers.map(h => {
+      const idx = h.lastIndexOf(".");
+      return idx === -1 ? h : h.substring(idx + 1);
+    });
+    const sheetRows: (string | number)[][] = [headers, shortHeaders];
+
+    for (const row of rows) {
+      if (!row.analysisResults) continue;
+      for (const res of row.analysisResults) {
+        sheetRows.push([
+          this.toStr(res.jobTitle),
+          this.toStr(res.sourceUrl),
+          this.toStr(res.requirementSummary),
+          this.toStr(res.reasoning),
+          res.confidenceScore ?? "",
+          Math.round(res.eloRating ?? 0),
+        ]);
+      }
+    }
+    return sheetRows;
+  }
+
+  private async writeInChunks(rows: (string | number)[][]): Promise<void> {
+    if (!rows.length) return;
+    const totalCols = rows[0].length;
+    let pointer = 1;
+    for (let i = 0; i < rows.length; i += this.chunkSize) {
+      const chunk = rows.slice(i, i + this.chunkSize);
+      const startRow = pointer;
+      const endRow = pointer + chunk.length - 1;
+      const endColLetter = this.colIdxToLetter(totalCols - 1);
+      const range = `${this.sheetName}!A${startRow}:${endColLetter}${endRow}`;
+      await this.sheetsConnector.updateRange(range, chunk as unknown as string[][]);
+      pointer += chunk.length;
+    }
+  }
+
+  private colIdxToLetter(idx: number): string {
+    let temp = idx;
+    let letter = "";
+    while (temp >= 0) {
+      letter = String.fromCharCode((temp % 26) + 65) + letter;
+      temp = Math.floor(temp / 26) - 1;
+    }
+    return letter;
+  }
+
+  private sanitiseData(data: (string | number)[][]): (string | number)[][] {
+    return data.map(row =>
+      row.map(cell => {
+        if (cell === undefined || cell === null) return "";
+        if (typeof cell === "number") return cell;
+        if (typeof cell === "object") return JSON.stringify(cell);
+        return String(cell);
+      })
+    );
+  }
+
+  private toStr(val: any): string {
+    return val !== undefined && val !== null ? String(val) : "";
+  }
+}

--- a/projects/skillsFirst/agents/src/legalResearch/educationRequirementsBarrierDeepResearchAgent.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/educationRequirementsBarrierDeepResearchAgent.ts
@@ -1,0 +1,104 @@
+import { PolicySynthAgent } from "@policysynth/agents/base/agent.js";
+import { PsAgent } from "@policysynth/agents/dbModels/agent.js";
+import { PsAiModelSize } from "@policysynth/agents/aiModelTypes.js";
+import { PsAgentClassCategories } from "@policysynth/agents/agentCategories.js";
+import { PsConnectorClassTypes } from "@policysynth/agents/connectorTypes.js";
+import { EducationType } from "../jobDescriptions/educationTypes.js";
+import type {
+  EducationRequirementResearchRow,
+} from "./types.js";
+import { SheetsEducationRequirementExportAgent } from "./educationExportSheet.js";
+import { JobTitleDeepResearchAgent } from "./jobTitleDeepResearch.js";
+import pLimit from "p-limit";
+
+export class EducationRequirementsBarrierDeepResearchAgent extends PolicySynthAgent {
+  declare memory: JobDescriptionMemoryData;
+
+  static readonly EDUCATION_DEEP_RESEARCH_AGENT_CLASS_BASE_ID = "2f7e2bd8-education-research";
+  static readonly EDUCATION_DEEP_RESEARCH_AGENT_CLASS_VERSION = 1;
+
+  constructor(agent: PsAgent, memory: JobDescriptionMemoryData, start: number, end: number) {
+    super(agent, memory, start, end);
+    this.memory = memory;
+  }
+
+  async process(): Promise<void> {
+    await this.updateRangedProgress(0, "Starting education requirement deep research");
+
+    const qualifyingJobs = (this.memory.jobDescriptions || []).filter((j) => {
+      const maxReq = j.degreeAnalysis?.maximumDegreeRequirement;
+      return (
+        j.degreeAnalysis?.needsCollegeDegree &&
+        (maxReq === EducationType.BachelorsDegree || maxReq === EducationType.AssociatesDegree)
+      );
+    });
+
+    const results: EducationRequirementResearchRow[] = [];
+    const limit = pLimit(5);
+    let processed = 0;
+    const tasks = qualifyingJobs.map((job) =>
+      limit(async () => {
+        const researcher = new JobTitleDeepResearchAgent(this.agent, this.memory, 0, 100);
+        const urls = (await researcher.doWebResearch(job.name, {
+          numberOfQueriesToGenerate: 12,
+          percentOfQueriesToSearch: 0.5,
+          percentOfResultsToScan: 0.5,
+          maxTopContentResultsToUse: 5,
+        })) as { url: string }[];
+        const row: EducationRequirementResearchRow = {
+          jobTitle: job.name,
+          analysisResults: urls.map((u) => ({
+            jobTitle: job.name,
+            sourceUrl: typeof u === "string" ? u : u.url,
+            requirementSummary: "",
+            reasoning: "",
+            confidenceScore: 0,
+          })),
+        };
+        results.push(row);
+        processed++;
+        await this.updateRangedProgress(
+          Math.floor((processed / qualifyingJobs.length) * 90),
+          `Research ${job.name}`
+        );
+      })
+    );
+
+    await Promise.all(tasks);
+
+    const exporter = new SheetsEducationRequirementExportAgent(
+      this.agent,
+      this.memory,
+      95,
+      100,
+      "Sheet1"
+    );
+    await exporter.processJsonData(results);
+    await this.updateRangedProgress(100, "Completed education requirement research");
+  }
+
+  static getAgentClass(): PsAgentClassCreationAttributes {
+    return {
+      class_base_id: this.EDUCATION_DEEP_RESEARCH_AGENT_CLASS_BASE_ID,
+      user_id: 0,
+      name: "Education Requirements Barrier Deep Research Agent",
+      version: this.EDUCATION_DEEP_RESEARCH_AGENT_CLASS_VERSION,
+      available: true,
+      configuration: {
+        category: PsAgentClassCategories.HRManagement,
+        subCategory: "legalResearch",
+        hasPublicAccess: false,
+        description:
+          "Research official sources supporting college degree requirements for job titles",
+        queueName: "EDUCATION_REQUIREMENTS_DEEP_RESEARCH",
+        imageUrl:
+          "https://aoi-storage-production.citizens.is/dl/b0235e4818d5c15a4b9f4dac59eb749--retina-1.png",
+        iconName: "education_requirements_deep_research",
+        capabilities: ["analysis", "text processing"],
+        requestedAiModelSizes: [PsAiModelSize.Small, PsAiModelSize.Medium, PsAiModelSize.Large],
+        supportedConnectors: [] as PsConnectorClassTypes[],
+        questions: [],
+      },
+    };
+  }
+}

--- a/projects/skillsFirst/agents/src/legalResearch/jobTitleDeepResearch.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/jobTitleDeepResearch.ts
@@ -1,0 +1,15 @@
+import { BaseDeepResearchAgent } from "../jobDescriptions/deepResearch/baseResearchAgent.js";
+
+export class JobTitleDeepResearchAgent extends BaseDeepResearchAgent {
+  override scanType: DeepResearchWebResearchTypes = "jobDescription";
+
+  licenseType: string = ""; // reused for job title
+
+  searchInstructions = `Search for official statutes, regulations, or government job classification documents that describe mandatory education requirements for the job title.`;
+
+  rankingInstructions = `Prioritize results that explicitly mention legal or regulatory education requirements for the job title.`;
+
+  attributeNameToUseForDedup = "url";
+
+  scanningSystemPrompt: string = `Analyze the provided search results snippets for the query "${this.searchInstructions}". Identify the single most promising official source URL detailing the education requirements for '\${this.licenseType}'. Output ONLY the URL. If no authoritative source is found, output "NOT_FOUND".`;
+}

--- a/projects/skillsFirst/agents/src/legalResearch/types.d.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/types.d.ts
@@ -1,0 +1,13 @@
+export interface EducationRequirementResearchResult extends PsEloRateable {
+  jobTitle: string;
+  sourceUrl: string;
+  requirementSummary: string;
+  reasoning: string;
+  confidenceScore: number;
+  error?: string;
+}
+
+export interface EducationRequirementResearchRow {
+  jobTitle: string;
+  analysisResults?: EducationRequirementResearchResult[];
+}


### PR DESCRIPTION
## Summary
- create new agent `EducationRequirementsBarrierDeepResearchAgent` for legal research
- add helper `JobTitleDeepResearchAgent`
- implement spreadsheet export for education requirement research results
- define new types and extend job description memory

## Testing
- `npm run build`