### PR TITLE
Add multi-level job description docs

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/multiLevel/README.md
+++ b/projects/skillsFirst/agents/src/jobDescriptions/multiLevel/README.md
@@ -15,3 +15,27 @@ This directory contains helpers for job descriptions that bundle several job lev
 4. Each generated sub‑level entry is saved back to memory and exported to Google Sheets.
 
 This approach allows a single multi‑level description to be broken into separate records so degree requirements, licensing checks and readability analysis run correctly for every job level.
+
+## Marking Multi-Level Jobs
+
+Set `multiLevelJob: true` on any `JobDescription` in memory to signal that it contains multiple levels. During processing the `JobDescriptionMultiLevelAnalysisAgent` will split the text into separate records and mark each new entry with `haveProcessedSubLevel: true` once the standard analysis chain completes. Both properties live on the `JobDescription` interface in `types.d.ts`.
+
+## Invocation Example
+
+The main workflow (`JobDescriptionAnalysisAgent`) instantiates the multi‑level agent after the standard review steps:
+
+```ts
+await this.updateRangedProgress(95, "Starting Multi-Level Job Description Analysis");
+
+const multiLevelAnalysisAgent = new JobDescriptionMultiLevelAnalysisAgent(
+  this.agent,
+  this.memory,
+  95,
+  100,
+  this
+);
+
+await multiLevelAnalysisAgent.process();
+```
+
+Refer back to the [job description README](../README.md) for an overview of the complete analysis workflow.


### PR DESCRIPTION
## Summary
- document how to flag multi-level job descriptions
- show how the `JobDescriptionMultiLevelAnalysisAgent` is invoked
- link back to the main job description README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ad9792320832eb517bcffc2117684