### PR TITLE
Add job description import example

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/imports/exampleImport.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/imports/exampleImport.ts
@@ -1,0 +1,30 @@
+import { SheetsJobDescriptionImportAgent } from "./sheetsImport.js";
+import { PsAgent } from "@policysynth/agents/dbModels/agent.js";
+
+async function run() {
+  // Assume `runAgents.ts` has already registered a Google Sheets connector
+  // for this agent in the database.
+  const agent = await PsAgent.findOne({ include: ["InputConnectors"] });
+  if (!agent) {
+    throw new Error("Agent not found");
+  }
+
+  const memory: any = {};
+  const importAgent = new SheetsJobDescriptionImportAgent(
+    agent,
+    memory,
+    0,
+    100,
+    "Sheet1"
+  );
+
+  const result = await importAgent.importJobDescriptions();
+  console.log(
+    `Imported ${result.jobDescriptions.length} job descriptions from ${result.connectorName}`
+  );
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add exampleImport.ts to show how to call `importJobDescriptions`
- document the import workflow including a short header table

## Testing
- `npm run build` in `agents/`

------
https://chatgpt.com/codex/tasks/task_e_684ad97cf978832e8f4ee68f4cb50cb8