### PR TITLE
Update Sheets export README

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/exports/README.md
+++ b/projects/skillsFirst/agents/src/jobDescriptions/exports/README.md
@@ -19,3 +19,32 @@ await exportAgent.processJsonData({
 
 The method will upload rows in chunks to avoid exceeding API limits. Adjust the
 sheet name in the constructor if your spreadsheet uses a different tab.
+
+## Constructor parameters
+
+- `agent` – Existing `PsAgent` used for logging and configuration.
+- `memory` – Object containing the job descriptions to export.
+- `startProgress`/`endProgress` – Percent range shown while exporting.
+- `sheetName` – Target tab name. Defaults to **Job Descriptions Analysis**.
+- `chunkSize` – Number of rows written per API call (default **500**).
+
+## Example header rows
+
+When exported, the first two rows provide the full object path and a shorter
+column name. The beginning of the sheet looks like:
+
+```
+agentId,titleCode,variant,classOfService,workWeek,bargainUnit,...
+agentId,titleCode,variant,classOfService,workWeek,bargainUnit,...
+...
+degreeAnalysis.needsCollegeDegree,needsCollegeDegree,
+```
+
+## Troubleshooting
+
+- **API rate limits** – Reduce `chunkSize` or wait if you encounter HTTP 429
+  errors from Google Sheets.
+- **Incorrect sheet name** – Ensure the `sheetName` parameter matches the tab
+  in your spreadsheet.
+- **Missing connector** – Verify a Google Sheets connector is registered before
+  running the export agent.


### PR DESCRIPTION
## Summary
- document SheetsJobDescriptionExportAgent constructor parameters
- show example header rows
- add troubleshooting tips for Google Sheets export

## Testing
- `npm run build` in `projects/skillsFirst/agents`

------
https://chatgpt.com/codex/tasks/task_e_684ad97e8690832e82f9d94c08650fa3