### PR TITLE
Add instructions for evaluation queues

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/evals/README.md
+++ b/projects/skillsFirst/agents/src/jobDescriptions/evals/README.md
@@ -10,3 +10,33 @@ The `SheetsComparisonAgent` imports job descriptions from all spreadsheet connec
 
 ## Queues
 `compareAgentQueue.ts` and `compareLicenseEducationQueue.ts` merely define BullMQ queues that run the evaluation agents. They do not implement comparison logic and can be ignored when reviewing the agents themselves.
+
+## Running the Queues
+
+1. Build the **projects/skillsFirst/agents** package:
+
+   ```bash
+   npm install
+   npm run build
+   ```
+
+2. Start the agent runner which registers the evaluation queues:
+
+   ```bash
+   node ts-out/jobDescriptions/runAgents.js
+   ```
+
+3. Enqueue a job for either queue using BullMQ. You can adapt
+   `triggerAgentQueue.ts` by changing the queue name to
+   `JOB_DESCRIPTION_COMPARE_SHEETS` or `COMPARE_LICENSE_EDUCATION`.
+
+The **SheetsComparisonAgent** prints a table of mismatched fields and the
+chosen connector directly to the console. The
+**CompareLicenseEducationAgent** writes its results to the `Comparison` sheet of
+the configured output spreadsheet. Results are also stored in memory under
+`memory.results` while the agent runs.
+
+Refer back to the [job description agents README](../README.md) as well as the
+[imports](../imports/README.md) and [exports](../exports/README.md)
+documentation for details on the agents and connectors these evaluation queues
+rely on.


### PR DESCRIPTION
## Summary
- document how to run `compareAgentQueue.ts` and `compareLicenseEducationQueue.ts`
- explain where their results are stored and link back to relevant agent docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ad97fb018832e955cd402f881ff8f