### PR TITLE
Connect legal research agent to queue

### DIFF
--- a/projects/skillsFirst/agents/src/legalResearch/README.md
+++ b/projects/skillsFirst/agents/src/legalResearch/README.md
@@ -12,7 +12,9 @@ This folder contains agents that find official evidence of college degree requir
 
 ## Queues
 
-No BullMQ queues are defined in this folder.
+- **EducationRequirementsDeepResearchQueue** – schedules
+  `EducationRequirementsBarrierDeepResearchAgent` jobs using the queue name
+  `EDUCATION_REQUIREMENTS_DEEP_RESEARCH`.
 
 ## Environment Variables
 

--- a/projects/skillsFirst/agents/src/legalResearch/educationRequirementsQueue.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/educationRequirementsQueue.ts
@@ -1,0 +1,36 @@
+import { PolicySynthAgentQueue } from "@policysynth/agents/base/agentQueue.js";
+import { EducationRequirementsBarrierDeepResearchAgent } from "./educationRequirementsBarrierDeepResearchAgent.js";
+
+export class EducationRequirementsDeepResearchQueue extends PolicySynthAgentQueue {
+  declare memory: JobDescriptionMemoryData;
+
+  get agentQueueName(): string {
+    return "EDUCATION_REQUIREMENTS_DEEP_RESEARCH";
+  }
+
+  get processors() {
+    return [
+      {
+        processor: EducationRequirementsBarrierDeepResearchAgent,
+        weight: 100,
+      },
+    ];
+  }
+
+  forceMemoryRestart = false;
+
+  async setupMemoryIfNeeded(agentId: number) {
+    const psAgent = await this.getOrCreatePsAgent(agentId);
+    this.logger.info(`Setting up memory for agent ${psAgent.id}`);
+
+    let agentMemory = this.agentMemoryMap.get(agentId);
+    if (!agentMemory) {
+      agentMemory = { agentId: psAgent.id };
+      this.agentMemoryMap.set(agentId, agentMemory);
+    } else {
+      this.logger.info(
+        `Memory already set up for agent ${psAgent.id}: `
+      );
+    }
+  }
+}

--- a/projects/skillsFirst/agents/src/runAgents.ts
+++ b/projects/skillsFirst/agents/src/runAgents.ts
@@ -15,6 +15,8 @@ import { JobTitleLicenseDegreeAnalysisQueue } from "./jobDescriptions/licenceDeg
 import { JobTitleLicenseDegreeAnalysisAgent } from "./jobDescriptions/licenceDegrees/licenceAnalysisAgent.js";
 import { CompareLicenseEducationQueue } from "./jobDescriptions/evals/compareLicenseEducationQueue.js";
 import { CompareLicenseEducationAgent } from "./jobDescriptions/evals/compareLicenseEducation.js";
+import { EducationRequirementsDeepResearchQueue } from "./legalResearch/educationRequirementsQueue.js";
+import { EducationRequirementsBarrierDeepResearchAgent } from "./legalResearch/educationRequirementsBarrierDeepResearchAgent.js";
 export class JobDescriptionAgentRunner extends PsBaseAgentRunner {
   protected agentClasses: PsAgentClassCreationAttributes[];
   protected connectorClasses: PsAgentConnectorClassCreationAttributes[];
@@ -27,6 +29,7 @@ export class JobDescriptionAgentRunner extends PsBaseAgentRunner {
       new JobDescriptionRewriterQueue(),
       new JobTitleLicenseDegreeAnalysisQueue(),
       new CompareLicenseEducationQueue(),
+      new EducationRequirementsDeepResearchQueue(),
     ];
 
     this.agentClasses = [
@@ -35,6 +38,7 @@ export class JobDescriptionAgentRunner extends PsBaseAgentRunner {
       JobDescriptionRewriterAgent.getAgentClass(),
       JobTitleLicenseDegreeAnalysisAgent.getAgentClass(),
       CompareLicenseEducationAgent.getAgentClass(),
+      EducationRequirementsBarrierDeepResearchAgent.getAgentClass(),
     ];
 
     this.connectorClasses = [


### PR DESCRIPTION
## Summary
- add `EducationRequirementsDeepResearchQueue` to schedule deep research work
- register the queue and agent class in the runner
- document the new queue in the legal research README

## Testing
- `npm run build` in `projects/skillsFirst/agents`

------
https://chatgpt.com/codex/tasks/task_e_684ae412d784832e8734e3c3219e4c32