### PR TITLE
Add topic slug routing

### DIFF
--- a/projects/ecasEric/webApp/src/services/adminServerApi.ts
+++ b/projects/ecasEric/webApp/src/services/adminServerApi.ts
@@ -160,6 +160,12 @@ export class AdminServerApi extends YpServerApi {
     return await this.fetchWrapper(`${this.baseUrlPath}/topics`) as TopicData[];
   }
 
+  async getTopic(idOrSlug: string | number): Promise<TopicData> {
+    return await this.fetchWrapper(
+      `${this.baseUrlPath}/topics/${idOrSlug}`
+    ) as TopicData;
+  }
+
   async createTopic(topicData: Omit<TopicData, 'id'>): Promise<TopicData> {
     return await this.fetchWrapper(`${this.baseUrlPath}/topics`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- add `getTopic` API on the adminServerApi service
- parse slug in router and load topics when navigating
- wire selected topic id into the chatbot component

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_684eee135180832e97faa1ba0cf80881