### PR TITLE
Fix admin routing logic

### DIFF
--- a/projects/ecasEric/webApp/src/eric-app.ts
+++ b/projects/ecasEric/webApp/src/eric-app.ts
@@ -34,7 +34,8 @@ interface Topic {
     language?: string;
 }
 
-const renderAdmin = true;
+const shouldRenderAdmin = () =>
+  window.location.pathname.startsWith('/admin');
 
 @customElement('eric-chatbot-app')
 export class EcasYeaChatBotApp extends PolicySynthWebApp {
@@ -456,7 +457,7 @@ export class EcasYeaChatBotApp extends PolicySynthWebApp {
     return formattedTime;
   }
   override render() {
-    if (renderAdmin) {
+    if (shouldRenderAdmin()) {
       if (window.location.pathname.includes('/admin/login')) {
         return html`
         <admin-login></admin-login>


### PR DESCRIPTION
## Summary
- only show admin routes when the URL path starts with `/admin`

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_684efd908a00832eb73836926651586a