### PR TITLE
Fix markdown parsing in ecasEric webapp

### DIFF
--- a/projects/ecasEric/webApp/src/base/litMarkdown.ts
+++ b/projects/ecasEric/webApp/src/base/litMarkdown.ts
@@ -119,9 +119,8 @@ export class MarkdownDirective extends AsyncDirective {
     }
 
     new Promise<string>((resolve, reject) => {
-      //@ts-ignore
-      marked.parse(rawMarkdown, (error: any, result: any) => {
-        if (error) return reject(error);
+      try {
+        const result = marked.parse(rawMarkdown);
 
         const cssStyles = `
           table {
@@ -191,9 +190,10 @@ export class MarkdownDirective extends AsyncDirective {
           </style>
           ${result}
         `;
-
         resolve(formattedMarkdown);
-      });
+      } catch (error) {
+        reject(error);
+      }
     })
       .then(rawHTML => {
         rawHTML = rawHTML.replace(/<a href="/g, '<a target="_blank" href="');


### PR DESCRIPTION
## Summary
- fix markdown directive by using the synchronous `marked.parse` API

## Testing
- `npx tsc -p projects/ecasEric/webApp/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684f1593a000832eabac1831425e0cf1