### PR TITLE
Fix topic description length

### DIFF
--- a/projects/ecasEric/webApp/src/admin/topic-manager.ts
+++ b/projects/ecasEric/webApp/src/admin/topic-manager.ts
@@ -260,7 +260,13 @@ export class TopicManager extends LitElement {
             <tr>
               <td title="${item.title}">${item.title}</td>
               <td title="${item.slug}">${item.slug}</td>
-              <td class="description" title="${item.description}">${item.description || '-'}</td>
+              <td class="description" title="${item.description}">
+                ${item.description
+                  ? item.description.length > 200
+                    ? item.description.substring(0, 200) + '...'
+                    : item.description
+                  : '-'}
+              </td>
               <td>${languageOptions.find(l => l.code === item.language)?.name || item.language}</td>
               <td class="actions">
                 <md-icon-button title="Edit Topic" @click=${() => this.openDialog(item)}><md-icon>edit</md-icon></md-icon-button>


### PR DESCRIPTION
## Summary
- truncate topic description in admin topic list to 200 chars

## Testing
- `npx tsc -p projects/ecasEric/webApp/tsconfig.json` *(fails: Parameter 'document' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ab7befc832e9d4644348ed6afdb