### PR TITLE
Fix Gemini chat history mapping

### DIFF
--- a/projects/ecasEric/webApi/src/chatbot/chatBot.ts
+++ b/projects/ecasEric/webApi/src/chatbot/chatBot.ts
@@ -338,7 +338,7 @@ Your thoughtful answer in markdown:
     // Convert chat history to Gemini format
     const history: Content[] = chatLogWithoutLastUserMessage.map(
         (msg: PsSimpleChatLog): Content => ({
-          role: msg.sender === "user" ? "user" : "model",
+          role: msg.sender === "user" || msg.sender === "you" ? "user" : "model",
           parts: [{ text: msg.message }],
         })
       );


### PR DESCRIPTION
## Summary
- handle chat logs that label user messages as `you`

## Testing
- `npx tsc -p projects/ecasEric/webApi/tsconfig.json --pretty false`

------
https://chatgpt.com/codex/tasks/task_e_684f41aa800c832eab9f0d626ca7f0ef