### PR TITLE
Add chat session admin review feature

### DIFF
--- a/projects/ecasEric/webApi/src/controllers/chatSessionController.ts
+++ b/projects/ecasEric/webApi/src/controllers/chatSessionController.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from 'express';
+import { BaseController } from '@policysynth/api/controllers/baseController.js';
+import WebSocket from 'ws';
+import { authMiddleware, roleGuard } from '../middlewares/authMiddleware.js';
+import { ChatSessionService } from '../services/chatSessionService.js';
+
+export class ChatSessionController extends BaseController {
+  public path = '/api/chat-sessions';
+  private chatSessionService = new ChatSessionService();
+
+  constructor(wsClients: Map<string, WebSocket>) {
+    super(wsClients);
+    this.initializeRoutes();
+  }
+
+  public initializeRoutes() {
+    this.router.get(this.path, authMiddleware, roleGuard('admin'), this.list);
+    this.router.get(`${this.path}/:id`, authMiddleware, roleGuard('admin'), this.getById);
+  }
+
+  private list = async (req: Request, res: Response) => {
+    const { page, pageSize } = req.query;
+    try {
+      const result = await this.chatSessionService.list({
+        page: page ? Number(page) : 1,
+        pageSize: pageSize ? Number(pageSize) : 20,
+      });
+      res.status(200).json(result);
+    } catch (error: any) {
+      console.error('Error listing chat sessions:', error);
+      res.status(500).send(error.message || 'Internal Server Error');
+    }
+  };
+
+  private getById = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    try {
+      const session = await this.chatSessionService.findById(Number(id));
+      if (!session) {
+        return res.status(404).send('Chat session not found');
+      }
+      res.status(200).json(session);
+    } catch (error: any) {
+      console.error('Error getting chat session:', error);
+      res.status(500).send(error.message || 'Internal Server Error');
+    }
+  };
+}

--- a/projects/ecasEric/webApi/src/routes.ts
+++ b/projects/ecasEric/webApi/src/routes.ts
@@ -5,6 +5,7 @@ import { TopicController } from './controllers/topicController.js';
 import { QAController } from './controllers/qaController.js';
 import { LinkController } from './controllers/linkController.js';
 import { ReviewController } from './controllers/reviewController.js';
+import { ChatSessionController } from './controllers/chatSessionController.js';
 import { AnalyticsController } from '@policysynth/api/controllers/analyticsController.js';
 import WebSocket from 'ws';
 
@@ -15,6 +16,7 @@ export const getControllers = (wsClients: Map<string, WebSocket>) => [
   new QAController(wsClients),
   new LinkController(wsClients),
   new ReviewController(wsClients),
+  new ChatSessionController(wsClients),
   new AnalyticsController(wsClients), // Existing controller
 ];
 
@@ -26,5 +28,6 @@ export const controllerClasses = [
   QAController,
   LinkController,
   ReviewController,
+  ChatSessionController,
   AnalyticsController, // Existing controller
 ];

--- a/projects/ecasEric/webApi/src/services/chatSessionService.ts
+++ b/projects/ecasEric/webApi/src/services/chatSessionService.ts
@@ -1,0 +1,26 @@
+import { ChatSession } from '../models/chatSession.model.js';
+import { Review } from '../models/review.model.js';
+import { AdminUser } from '../models/adminUser.model.js';
+
+interface ListParams {
+  page?: number;
+  pageSize?: number;
+}
+
+export class ChatSessionService {
+  async list({ page = 1, pageSize = 20 }: ListParams) {
+    const offset = (page - 1) * pageSize;
+    return ChatSession.findAndCountAll({
+      limit: pageSize,
+      offset,
+      order: [['createdAt', 'DESC']],
+      include: [{ model: Review, include: [{ model: AdminUser, as: 'reviewer', attributes: ['id', 'email'] }] }]
+    });
+  }
+
+  async findById(id: number) {
+    return ChatSession.findByPk(id, {
+      include: [{ model: Review, include: [{ model: AdminUser, as: 'reviewer', attributes: ['id', 'email'] }] }]
+    });
+  }
+}

--- a/projects/ecasEric/webApp/src/admin/admin-dashboard.ts
+++ b/projects/ecasEric/webApp/src/admin/admin-dashboard.ts
@@ -8,6 +8,7 @@ import './topic-manager.js';
 import './qa-manager.js';
 import './link-manager.js';
 import './review-manager.js';
+import './chat-session-manager.js';
 
 // Import Material Web Components
 import '@material/web/labs/navigationbar/navigation-bar.js';
@@ -105,9 +106,16 @@ export class AdminDashboard extends LitElement { // Consider connect(store)(LitE
           @click=${() => (this.selectedView = 'reviews')}>
              <md-icon slot="active-icon">rate_review</md-icon>
              <md-icon slot="inactive-icon">rate_review</md-icon>
-          </md-navigation-tab>
-          <div class="spacer"></div>
-          <md-text-button class="logout-button" @click=${this.handleLogout}>
+        </md-navigation-tab>
+        <md-navigation-tab
+          label="Chat Sessions"
+          ?active=${this.selectedView === 'chats'}
+          @click=${() => (this.selectedView = 'chats')}>
+             <md-icon slot="active-icon">forum</md-icon>
+             <md-icon slot="inactive-icon">forum</md-icon>
+        </md-navigation-tab>
+        <div class="spacer"></div>
+        <md-text-button class="logout-button" @click=${this.handleLogout}>
               Logout
               <md-icon slot="icon">logout</md-icon>
             </md-text-button>
@@ -125,6 +133,8 @@ export class AdminDashboard extends LitElement { // Consider connect(store)(LitE
         return html`<link-manager></link-manager>`;
       case 'reviews':
         return html`<review-manager></review-manager>`;
+      case 'chats':
+        return html`<chat-session-manager></chat-session-manager>`;
       default:
         return html`<div>Select a section</div>`;
     }

--- a/projects/ecasEric/webApp/src/admin/chat-session-manager.ts
+++ b/projects/ecasEric/webApp/src/admin/chat-session-manager.ts
@@ -1,0 +1,203 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { adminServerApi, ChatSessionData, TopicData, ReviewCreateDTO } from '../services/adminServerApi.js';
+import '@material/web/button/outlined-button.js';
+import '@material/web/button/filled-button.js';
+import '@material/web/dialog/dialog.js';
+import '@material/web/progress/circular-progress.js';
+import '@material/web/slider/slider.js';
+
+@customElement('chat-session-manager')
+export class ChatSessionManager extends LitElement {
+  @state() private sessions: ChatSessionData[] = [];
+  @state() private topics: TopicData[] = [];
+  @state() private loading = false;
+  @state() private error: string | null = null;
+  @state() private page = 1;
+  @state() private pageSize = 10;
+  @state() private totalItems = 0;
+
+  @state() private dialogOpen = false;
+  @state() private currentSession: ChatSessionData | null = null;
+  @state() private reviewRating = 3;
+  @state() private reviewNotes = '';
+
+  async connectedCallback() {
+    super.connectedCallback();
+    await this.fetchTopics();
+    await this.fetchSessions();
+  }
+
+  async fetchTopics() {
+    try {
+      this.topics = await adminServerApi.getTopics();
+    } catch (e: any) {
+      this.error = e.message;
+    }
+  }
+
+  async fetchSessions() {
+    this.loading = true;
+    this.error = null;
+    try {
+      const result = await adminServerApi.listChatSessions(this.page, this.pageSize);
+      this.sessions = result.rows;
+      this.totalItems = result.count;
+    } catch (e: any) {
+      this.error = e.message;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  openDialog(session: ChatSessionData) {
+    this.currentSession = session;
+    const existing = session.Reviews && session.Reviews[0];
+    this.reviewRating = existing ? existing.rating : 3;
+    this.reviewNotes = existing?.notes || '';
+    this.dialogOpen = true;
+  }
+
+  closeDialog() {
+    this.dialogOpen = false;
+    this.currentSession = null;
+  }
+
+  topicTitle(id?: number) {
+    const t = this.topics.find(t => t.id === id);
+    return t ? t.title : 'N/A';
+  }
+
+  renderRating(rating: number) {
+    let stars = '';
+    for (let i = 0; i < 5; i++) {
+      stars += i < rating ? '★' : '☆';
+    }
+    return stars;
+  }
+
+  async saveReview() {
+    if (!this.currentSession) return;
+    const dto: ReviewCreateDTO = {
+      chatSessionId: this.currentSession.id,
+      rating: this.reviewRating,
+      notes: this.reviewNotes,
+    };
+    this.loading = true;
+    try {
+      await adminServerApi.createReview(dto);
+      await this.fetchSessions();
+      this.closeDialog();
+    } catch (e: any) {
+      this.error = e.message;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  handleNextPage() {
+    if (this.page * this.pageSize < this.totalItems) {
+      this.page++;
+      this.fetchSessions();
+    }
+  }
+
+  handlePrevPage() {
+    if (this.page > 1) {
+      this.page--;
+      this.fetchSessions();
+    }
+  }
+
+  static override styles = css`
+    :host {
+      display: block;
+      padding: 16px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 16px;
+    }
+    th, td {
+      padding: 8px;
+      text-align: left;
+      border-bottom: 1px solid var(--md-sys-color-outline-variant);
+      max-width: 220px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    th {
+      background-color: var(--md-sys-color-surface-container-low);
+    }
+    .pagination {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      margin-top: 16px;
+    }
+    .pagination span {
+      margin: 0 8px;
+    }
+    .chat-log {
+      max-height: 300px;
+      overflow-y: auto;
+      border: 1px solid var(--md-sys-color-outline-variant);
+      padding: 8px;
+    }
+    .chat-line {
+      margin-bottom: 4px;
+    }
+  `;
+
+  render() {
+    return html`
+      ${this.loading ? html`<md-circular-progress indeterminate></md-circular-progress>` : ''}
+      ${this.error ? html`<p style="color:red;">Error: ${this.error}</p>` : ''}
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Topic</th>
+            <th>Rating</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${this.sessions.map(s => html`
+            <tr>
+              <td>${s.createdAt ? new Date(s.createdAt).toLocaleDateString() : '-'}</td>
+              <td>${this.topicTitle(s.topicId)}</td>
+              <td>${s.Reviews && s.Reviews.length > 0 ? this.renderRating(s.Reviews[0].rating) : '-'}</td>
+              <td><md-outlined-button @click=${() => this.openDialog(s)}>View & Rate</md-outlined-button></td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+      <div class="pagination">
+        <md-outlined-button @click=${this.handlePrevPage} ?disabled=${this.page <= 1 || this.loading}>Prev</md-outlined-button>
+        <span>Page ${this.page} of ${Math.ceil(this.totalItems / this.pageSize)}</span>
+        <md-outlined-button @click=${this.handleNextPage} ?disabled=${this.page * this.pageSize >= this.totalItems || this.loading}>Next</md-outlined-button>
+      </div>
+
+      <md-dialog ?open=${this.dialogOpen} @closed=${this.closeDialog}>
+        <div slot="headline">Chat Session Review</div>
+        <div slot="content">
+          ${this.currentSession ? html`
+            <div class="chat-log">
+              ${Array.isArray(this.currentSession.chatLogJson) ? this.currentSession.chatLogJson.map((line: any) => html`<div class="chat-line"><b>${line.sender}:</b> ${line.message}</div>`) : ''}
+            </div>
+            <label>Rating: ${this.renderRating(this.reviewRating)}</label>
+            <md-slider min="1" max="5" step="1" .value=${this.reviewRating} @change=${(e: any) => this.reviewRating = Number(e.target.value)} ticks labelled></md-slider>
+            <md-outlined-text-field label="Notes" type="textarea" rows="3" .value=${this.reviewNotes} @input=${(e: any) => this.reviewNotes = e.target.value}></md-outlined-text-field>
+          ` : ''}
+        </div>
+        <div slot="actions">
+          <md-outlined-button @click=${this.closeDialog}>Cancel</md-outlined-button>
+          <md-filled-button @click=${this.saveReview} ?disabled=${this.loading}>Save</md-filled-button>
+        </div>
+      </md-dialog>
+    `;
+  }
+}

--- a/projects/ecasEric/webApp/src/services/adminServerApi.ts
+++ b/projects/ecasEric/webApp/src/services/adminServerApi.ts
@@ -89,6 +89,23 @@ export interface ReviewListResponse {
     count: number;
 }
 
+// --- Chat Session Interfaces ---
+export interface ChatSessionData {
+    id: number;
+    topicId?: number;
+    userId?: string;
+    chatLogJson?: any;
+    legacyMemoryId?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    Reviews?: ReviewData[];
+}
+
+export interface ChatSessionListResponse {
+    rows: ChatSessionData[];
+    count: number;
+}
+
 export class AdminServerApi extends YpServerApi {
   constructor(urlPath: string = '/api') {
     super();
@@ -266,6 +283,19 @@ export class AdminServerApi extends YpServerApi {
     return await this.fetchWrapper(`${this.baseUrlPath}/links/${id}`, {
         method: 'DELETE',
     }, true, 'link-delete-error', false) as { message: string };
+  }
+
+  // --- Chat Session ---
+  async listChatSessions(page = 1, pageSize = 20): Promise<ChatSessionListResponse> {
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    params.set('pageSize', String(pageSize));
+    const query = params.toString();
+    return await this.fetchWrapper(`${this.baseUrlPath}/chat-sessions?${query}`) as ChatSessionListResponse;
+  }
+
+  async getChatSession(id: number): Promise<ChatSessionData> {
+    return await this.fetchWrapper(`${this.baseUrlPath}/chat-sessions/${id}`) as ChatSessionData;
   }
 
   // --- Review CRUD ---


### PR DESCRIPTION
## Summary
- add ChatSessionService and controller to list chat sessions
- expose chat session API routes
- expand AdminServerApi with chat session types and methods
- create chat-session-manager admin component
- add chat sessions tab to admin dashboard

## Testing
- `npx tsc` in `projects/ecasEric/webApp`
- `npx tsc` in `projects/ecasEric/webApi`


------
https://chatgpt.com/codex/tasks/task_e_68509f5bba0c832e812694165ea4f2ea