### PR TITLE
Fix Sequelize model field definitions

### DIFF
--- a/projects/ecasEric/webApi/src/models/adminUser.model.ts
+++ b/projects/ecasEric/webApi/src/models/adminUser.model.ts
@@ -13,11 +13,11 @@ interface AdminUserAttributes {
 interface AdminUserCreationAttributes extends Optional<AdminUserAttributes, 'id'> {}
 
 class AdminUser extends Model<AdminUserAttributes, AdminUserCreationAttributes> implements AdminUserAttributes {
-  // Declare fields for TS and to satisfy implements, Sequelize handles them.
-  public id!: number;
-  public email!: string;
-  public passwordHash!: string;
-  public role!: 'admin' | 'editor';
+  // Declare fields for TS without initializing them to avoid shadowing Sequelize accessors
+  declare id: number;
+  declare email: string;
+  declare passwordHash: string;
+  declare role: 'admin' | 'editor';
 
   // No temporary password?: string; field needed
 

--- a/projects/ecasEric/webApi/src/models/chatSession.model.ts
+++ b/projects/ecasEric/webApi/src/models/chatSession.model.ts
@@ -13,14 +13,14 @@ interface ChatSessionAttributes {
 interface ChatSessionCreationAttributes extends Optional<ChatSessionAttributes, 'id' | 'topicId' | 'userId' | 'chatLogJson' | 'legacyMemoryId'> {}
 
 class ChatSession extends Model<ChatSessionAttributes, ChatSessionCreationAttributes> implements ChatSessionAttributes {
-  public id!: number;
-  public topicId?: number;
-  public userId?: string;
-  public chatLogJson?: object;
-  public legacyMemoryId?: string;
+  declare id: number;
+  declare topicId?: number;
+  declare userId?: string;
+  declare chatLogJson?: object;
+  declare legacyMemoryId?: string;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 
   // Possible associations to Topic and AdminUser (if userId maps to AdminUser.id)
 }

--- a/projects/ecasEric/webApi/src/models/countryLink.model.ts
+++ b/projects/ecasEric/webApi/src/models/countryLink.model.ts
@@ -13,17 +13,17 @@ interface CountryLinkAttributes {
 interface CountryLinkCreationAttributes extends Optional<CountryLinkAttributes, 'id' | 'title'> {}
 
 class CountryLink extends Model<CountryLinkAttributes, CountryLinkCreationAttributes> implements CountryLinkAttributes {
-  public id!: number;
-  public topicId!: number;
-  public countryCode!: string;
-  public url!: string;
-  public title?: string;
+  declare id: number;
+  declare topicId: number;
+  declare countryCode: string;
+  declare url: string;
+  declare title?: string;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 
   // Association mixins
-  public getTopic!: BelongsToGetAssociationMixin<Topic>;
+  declare getTopic: BelongsToGetAssociationMixin<Topic>;
 }
 
 CountryLink.init(

--- a/projects/ecasEric/webApi/src/models/qaPair.model.ts
+++ b/projects/ecasEric/webApi/src/models/qaPair.model.ts
@@ -22,19 +22,19 @@ interface QAPairAttributes {
 interface QAPairCreationAttributes extends Optional<QAPairAttributes, 'id' | 'embeddingUuid' | 'questionType' | 'source'> {}
 
 class QAPair extends Model<QAPairAttributes, QAPairCreationAttributes> implements QAPairAttributes {
-  public id!: number;
-  public topicId!: number;
-  public question!: string;
-  public answer!: string;
-  public embeddingUuid?: string;
-  public questionType?: QAPairQuestionType;
-  public source?: string;
+  declare id: number;
+  declare topicId: number;
+  declare question: string;
+  declare answer: string;
+  declare embeddingUuid?: string;
+  declare questionType?: QAPairQuestionType;
+  declare source?: string;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 
   // Association mixins
-  public getTopic!: BelongsToGetAssociationMixin<Topic>;
+  declare getTopic: BelongsToGetAssociationMixin<Topic>;
 
   // Placeholder for vector store synchronization hook
   public static addHookForVectorSync(): void {

--- a/projects/ecasEric/webApi/src/models/review.model.ts
+++ b/projects/ecasEric/webApi/src/models/review.model.ts
@@ -17,21 +17,21 @@ interface ReviewAttributes {
 interface ReviewCreationAttributes extends Optional<ReviewAttributes, 'id' | 'qaPairId' | 'chatSessionId' | 'answerHash' | 'notes' | 'reviewerId'> {}
 
 class Review extends Model<ReviewAttributes, ReviewCreationAttributes> implements ReviewAttributes {
-  public id!: number;
-  public qaPairId?: number;
-  public chatSessionId?: number;
-  public answerHash?: string;
-  public rating!: number;
-  public notes?: string;
-  public reviewerId?: number;
+  declare id: number;
+  declare qaPairId?: number;
+  declare chatSessionId?: number;
+  declare answerHash?: string;
+  declare rating: number;
+  declare notes?: string;
+  declare reviewerId?: number;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 
   // Association mixins
-  public getQAPair!: BelongsToGetAssociationMixin<QAPair>;
-  public getChatSession!: BelongsToGetAssociationMixin<ChatSession>;
-  public getReviewer!: BelongsToGetAssociationMixin<AdminUser>;
+  declare getQAPair: BelongsToGetAssociationMixin<QAPair>;
+  declare getChatSession: BelongsToGetAssociationMixin<ChatSession>;
+  declare getReviewer: BelongsToGetAssociationMixin<AdminUser>;
 
   // Static method for aggregation
   static async aggregateForQaPair(qaPairId: number): Promise<{ avgRating: number | null; count: number }> {

--- a/projects/ecasEric/webApi/src/models/topic.model.ts
+++ b/projects/ecasEric/webApi/src/models/topic.model.ts
@@ -12,14 +12,14 @@ interface TopicAttributes {
 interface TopicCreationAttributes extends Optional<TopicAttributes, 'id' | 'description'> {}
 
 class Topic extends Model<TopicAttributes, TopicCreationAttributes> implements TopicAttributes {
-  public id!: number;
-  public slug!: string;
-  public title!: string;
-  public description?: string;
-  public language!: string;
+  declare id: number;
+  declare slug: string;
+  declare title: string;
+  declare description?: string;
+  declare language: string;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 }
 
 Topic.init(


### PR DESCRIPTION
## Summary
- prevent Sequelize getter/setter shadowing by changing class fields to `declare`
- update all `webApi` models

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_6850b0d8fdb0832eacc1082e2c76e17e