### PR TITLE
Add chat session filters

### DIFF
--- a/projects/ecasEric/webApi/src/controllers/chatSessionController.ts
+++ b/projects/ecasEric/webApi/src/controllers/chatSessionController.ts
@@ -19,11 +19,13 @@ export class ChatSessionController extends BaseController {
   }
 
   private list = async (req: Request, res: Response) => {
-    const { page, pageSize } = req.query;
+    const { page, pageSize, topicId, minRating } = req.query;
     try {
       const result = await this.chatSessionService.list({
         page: page ? Number(page) : 1,
         pageSize: pageSize ? Number(pageSize) : 20,
+        topicId: topicId ? Number(topicId) : undefined,
+        minRating: minRating ? Number(minRating) : undefined,
       });
       res.status(200).json(result);
     } catch (error: any) {

--- a/projects/ecasEric/webApi/src/services/chatSessionService.ts
+++ b/projects/ecasEric/webApi/src/services/chatSessionService.ts
@@ -1,20 +1,33 @@
 import { ChatSession } from '../models/chatSession.model.js';
 import { Review } from '../models/review.model.js';
 import { AdminUser } from '../models/adminUser.model.js';
+import { Op } from 'sequelize';
 
 interface ListParams {
   page?: number;
   pageSize?: number;
+  topicId?: number;
+  minRating?: number;
 }
 
 export class ChatSessionService {
-  async list({ page = 1, pageSize = 20 }: ListParams) {
+  async list({ page = 1, pageSize = 20, topicId, minRating }: ListParams) {
     const offset = (page - 1) * pageSize;
+    const reviewWhere: any = {};
+    if (minRating !== undefined) {
+      reviewWhere.rating = { [Op.gte]: minRating };
+    }
     return ChatSession.findAndCountAll({
+      where: topicId ? { topicId } : undefined,
       limit: pageSize,
       offset,
       order: [['createdAt', 'DESC']],
-      include: [{ model: Review, include: [{ model: AdminUser, as: 'reviewer', attributes: ['id', 'email'] }] }]
+      include: [{
+        model: Review,
+        where: Object.keys(reviewWhere).length > 0 ? reviewWhere : undefined,
+        required: minRating !== undefined,
+        include: [{ model: AdminUser, as: 'reviewer', attributes: ['id', 'email'] }]
+      }]
     });
   }
 

--- a/projects/ecasEric/webApp/src/services/adminServerApi.ts
+++ b/projects/ecasEric/webApp/src/services/adminServerApi.ts
@@ -286,12 +286,14 @@ export class AdminServerApi extends YpServerApi {
   }
 
   // --- Chat Session ---
-  async listChatSessions(page = 1, pageSize = 20): Promise<ChatSessionListResponse> {
-    const params = new URLSearchParams();
-    params.set('page', String(page));
-    params.set('pageSize', String(pageSize));
-    const query = params.toString();
-    return await this.fetchWrapper(`${this.baseUrlPath}/chat-sessions?${query}`) as ChatSessionListResponse;
+  async listChatSessions(params: { page?: number; pageSize?: number; topicId?: number; minRating?: number } = {}): Promise<ChatSessionListResponse> {
+    const query = new URLSearchParams();
+    if (params.page !== undefined) query.set('page', String(params.page));
+    if (params.pageSize !== undefined) query.set('pageSize', String(params.pageSize));
+    if (params.topicId !== undefined) query.set('topicId', String(params.topicId));
+    if (params.minRating !== undefined) query.set('minRating', String(params.minRating));
+    const queryString = query.toString();
+    return await this.fetchWrapper(`${this.baseUrlPath}/chat-sessions${queryString ? '?' + queryString : ''}`) as ChatSessionListResponse;
   }
 
   async getChatSession(id: number): Promise<ChatSessionData> {


### PR DESCRIPTION
## Summary
- support topic and rating filters in chat session service and controller
- extend admin API to pass topic/minRating
- add topic and min rating filters to chat session manager UI

## Testing
- `npx tsc -p projects/ecasEric/webApp/tsconfig.json`
- `npx tsc -p projects/ecasEric/webApi/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6850b53b79f0832e890b1ae00fa18e86