### PR TITLE
Add date filters to search API

### DIFF
--- a/agents/docs/src/webResearch/bingSearchApi.md
+++ b/agents/docs/src/webResearch/bingSearchApi.md
@@ -20,12 +20,13 @@ Performs a search query using the Bing Search API and returns the search results
 
 | Name       | Parameters                  | Return Type          | Description                                                                 |
 |------------|-----------------------------|----------------------|-----------------------------------------------------------------------------|
-| search     | query: string, numberOfResults: number | Promise<PsSearchResultItem[]> | Executes a search query and returns an array of search result items. |
+| search     | query: string, numberOfResults: number, options?: PsSearchOptions | Promise<PsSearchResultItem[]> | Executes a search query and returns an array of search result items. |
 
 #### Parameters
 
 - `query` (string): The search query string.
 - `numberOfResults` (number): The number of search results to retrieve. The Bing API allows specifying a count up to a certain limit (commonly 50).
+- `options?` (`PsSearchOptions`): Optional search modifiers such as `before` or `after` dates.
 
 #### Return Type
 
@@ -37,7 +38,7 @@ Performs a search query using the Bing Search API and returns the search results
 import { BingSearchApi } from '@policysynth/agents/webResearch/bingSearchApi.js';
 
 const bingSearch = new BingSearchApi();
-bingSearch.search("example query", 10)
+bingSearch.search("example query", 10, { before: "2024/01/01" })
   .then(results => {
     console.log(results);
   })

--- a/agents/docs/src/webResearch/googleSearchApi.md
+++ b/agents/docs/src/webResearch/googleSearchApi.md
@@ -12,7 +12,7 @@ The `GoogleSearchApi` class is a specialized agent that extends the `PolicySynth
 
 | Name       | Parameters        | Return Type          | Description                 |
 |------------|-------------------|----------------------|-----------------------------|
-| search     | query: string, numberOfResults: number | Promise<PsSearchResultItem[]> | Performs a search using the Google Custom Search API and returns an array of search results. |
+| search     | query: string, numberOfResults: number, options?: PsSearchOptions | Promise<PsSearchResultItem[]> | Performs a search using the Google Custom Search API and returns an array of search results. |
 
 ### Method: `search`
 
@@ -20,6 +20,7 @@ The `GoogleSearchApi` class is a specialized agent that extends the `PolicySynth
 
 - `query: string`: The search query string.
 - `numberOfResults: number`: The number of search results to retrieve.
+- `options?: PsSearchOptions`: Optional search modifiers such as `before` or `after` dates.
 
 #### Returns
 
@@ -39,7 +40,8 @@ async function exampleUsage() {
   try {
     const results = await googleSearchApi.search(
       "liberal democracies: issues and solutions",
-      20
+      20,
+      { after: "2024/01/01" }
     );
     console.log("Search results:", results);
   } catch (error) {

--- a/agents/docs/src/webResearch/searchWeb.md
+++ b/agents/docs/src/webResearch/searchWeb.md
@@ -12,8 +12,8 @@ The `BaseSearchWebAgent` class is designed to perform web searches using either 
 
 | Name            | Parameters                                      | Return Type                  | Description                                                                 |
 |-----------------|-------------------------------------------------|------------------------------|-----------------------------------------------------------------------------|
-| callSearchApi   | query: string, numberOfResults: number          | Promise<PsSearchResultItem[]>| Calls the appropriate search API (Google or Bing) based on available keys.  |
-| getQueryResults | queriesToSearch: string[], id: string, numberOfResults: number = 10 | Promise<{ searchResults: PsSearchResultItem[] }> | Retrieves search results for a list of queries, ensuring no duplicate URLs. |
+| callSearchApi   | query: string, numberOfResults: number, options?: PsSearchOptions          | Promise<PsSearchResultItem[]>| Calls the appropriate search API (Google or Bing) based on available keys.  |
+| getQueryResults | queriesToSearch: string[], id: string, numberOfResults: number = 10, options?: PsSearchOptions | Promise<{ searchResults: PsSearchResultItem[] }> | Retrieves search results for a list of queries, ensuring no duplicate URLs. |
 
 ## Example
 
@@ -35,6 +35,7 @@ This method determines which search API to use based on the environment variable
 - **Parameters:**
   - `query`: The search query string.
   - `numberOfResults`: The number of search results to retrieve.
+  - `options?`: Optional `PsSearchOptions` with `before` or `after` date filters.
 
 - **Returns:** A promise that resolves to an array of `PsSearchResultItem` containing the search results.
 
@@ -48,6 +49,7 @@ This method performs searches for a list of queries and returns the combined res
   - `queriesToSearch`: An array of search query strings.
   - `id`: A unique identifier used to track seen URLs.
   - `numberOfResults`: The number of search results to retrieve per query (default is 10).
+  - `options?`: Optional `PsSearchOptions` forwarded to the search API.
 
 - **Returns:** A promise that resolves to an object containing the `searchResults`, which is an array of `PsSearchResultItem`.
 

--- a/agents/docs/src/webResearch/searchWebWithAi.md
+++ b/agents/docs/src/webResearch/searchWebWithAi.md
@@ -29,6 +29,7 @@ Performs a search using either the Google Search API or the Bing Search API, dep
 
 - `query`: `string` - The search query.
 - `numberOfResults`: `number` - The number of results to fetch.
+- `options?`: `PsSearchOptions` - Optional modifiers such as `before` or `after` dates.
 
 #### Returns
 
@@ -47,6 +48,7 @@ Fetches search results for a list of queries and deduplicates the results based 
 - `queriesToSearch`: `string[]` - An array of search queries.
 - `id`: `string` - An identifier used to track seen URLs.
 - `numberOfResults`: `number` (optional) - The number of results to fetch per query. Defaults to 10.
+- `options?`: `PsSearchOptions` - Optional modifiers forwarded to the search API.
 
 #### Returns
 
@@ -63,7 +65,9 @@ const memory = {/* memory initialization */};
 const searchAgent = new BaseSearchWebAgentWithAi(agent, memory);
 
 const queries = ["example query 1", "example query 2"];
-const results = await searchAgent.getQueryResults(queries, "uniqueId");
+const results = await searchAgent.getQueryResults(queries, "uniqueId", 10, {
+  before: "2024/01/01"
+});
 
 console.log(results.searchResults);
 ```

--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -206,6 +206,11 @@ interface PsSearchResultItem extends PsEloRateable {
 
 type SearchResultItem = PsSearchResultItem[];
 
+interface PsSearchOptions {
+  before?: string;
+  after?: string;
+}
+
 interface PsAgentBaseMemoryData {
   startTime?: number;
 }

--- a/agents/src/deepResearch/bingSearchApi.ts
+++ b/agents/src/deepResearch/bingSearchApi.ts
@@ -15,8 +15,16 @@ export class BingSearchApi extends PolicySynthSimpleAgentBase {
 
   public async search(
     query: string,
-    numberOfResults: number
+    numberOfResults: number,
+    options: PsSearchOptions = {}
   ): Promise<PsSearchResultItem[]> {
+    let finalQuery = query;
+    if (options.before) {
+      finalQuery += ` before:${options.before}`;
+    }
+    if (options.after) {
+      finalQuery += ` after:${options.after}`;
+    }
     // Bing API allows specifying count up to a certain limit (commonly 50)
     // For simplicity, we assume numberOfResults <= 50. If needed, multiple calls could be implemented similarly to Google.
     const maxBingResults = numberOfResults > 50 ? 50 : numberOfResults;
@@ -24,7 +32,7 @@ export class BingSearchApi extends PolicySynthSimpleAgentBase {
       method: "GET",
       url:
         `https://api.cognitive.microsoft.com/bing/v7.0/search?count=${maxBingResults}&q=` +
-        encodeURIComponent(query),
+        encodeURIComponent(finalQuery),
       headers: {
         "Ocp-Apim-Subscription-Key": this.SUBSCRIPTION_KEY!,
       },
@@ -72,7 +80,7 @@ export class BingSearchApi extends PolicySynthSimpleAgentBase {
         // Once the call is successful, no more retries are needed
         retry = false;
       } catch (e: any) {
-        this.logger.error(`Failed to get search data for ${query}`);
+        this.logger.error(`Failed to get search data for ${finalQuery}`);
         this.logger.error("Bing Search Error: " + e.message);
         this.logger.error(e);
         retryCount++;

--- a/agents/src/deepResearch/googleSearchApi.ts
+++ b/agents/src/deepResearch/googleSearchApi.ts
@@ -42,8 +42,16 @@ export class GoogleSearchApi extends PolicySynthSimpleAgentBase {
 
   public async search(
     query: string,
-    numberOfResults: number
+    numberOfResults: number,
+    options: PsSearchOptions = {}
   ): Promise<PsSearchResultItem[]> {
+    let finalQuery = query;
+    if (options.before) {
+      finalQuery += ` before:${options.before}`;
+    }
+    if (options.after) {
+      finalQuery += ` after:${options.after}`;
+    }
     const outResults: PsSearchResultItem[] = [];
     const maxPerRequest = 10;
 
@@ -58,7 +66,7 @@ export class GoogleSearchApi extends PolicySynthSimpleAgentBase {
       );
 
       const url = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(
-        query
+        finalQuery
       )}&key=${process.env.GOOGLE_SEARCH_API_KEY}&cx=${
         process.env.GOOGLE_SEARCH_API_CX_ID
       }&num=${resultsToFetch}&start=${startIndex}`;

--- a/agents/src/deepResearch/searchWeb.ts
+++ b/agents/src/deepResearch/searchWeb.ts
@@ -5,25 +5,38 @@ import { PolicySynthAgentBase } from "../base/agentBase.js";
 export class BaseSearchWebAgent extends PolicySynthAgentBase {
   seenUrls: Map<string, Set<string>> = new Map();
 
-  async callSearchApi(query: string, numberOfResults: number): Promise<PsSearchResultItem[]> {
+  async callSearchApi(
+    query: string,
+    numberOfResults: number,
+    options: PsSearchOptions = {}
+  ): Promise<PsSearchResultItem[]> {
     if (process.env.GOOGLE_SEARCH_API_KEY &&
         process.env.GOOGLE_SEARCH_API_CX_ID) {
       const googleSearchApi = new GoogleSearchApi();
-      return await googleSearchApi.search(query, numberOfResults);
+      return await googleSearchApi.search(query, numberOfResults, options);
     } else if (process.env.AZURE_BING_SEARCH_KEY) {
       const bingSearchApi = new BingSearchApi();
-      return await bingSearchApi.search(query, numberOfResults);
+      return await bingSearchApi.search(query, numberOfResults, options);
     } else {
       this.logger.error("Missing search API key");
       throw new Error("Missing search API key");
     }
   }
 
-  async getQueryResults(queriesToSearch: string[], id: string, numberOfResults: number = 10) {
+  async getQueryResults(
+    queriesToSearch: string[],
+    id: string,
+    numberOfResults: number = 10,
+    options: PsSearchOptions = {}
+  ) {
     let searchResults: PsSearchResultItem[] = [];
 
     for (let q = 0; q < queriesToSearch.length; q++) {
-      const generalSearchData = await this.callSearchApi(queriesToSearch[q], numberOfResults);
+      const generalSearchData = await this.callSearchApi(
+        queriesToSearch[q],
+        numberOfResults,
+        options
+      );
 
       if (generalSearchData) {
         searchResults = [...searchResults, ...generalSearchData];

--- a/agents/src/deepResearch/searchWebWithAi.ts
+++ b/agents/src/deepResearch/searchWebWithAi.ts
@@ -1,6 +1,5 @@
 import { BingSearchApi } from "./bingSearchApi.js";
 import { GoogleSearchApi } from "./googleSearchApi.js";
-import { PolicySynthAgentBase } from "../base/agentBase.js";
 import { PolicySynthAgent } from "../base/agent.js";
 import { PsAgent } from "../dbModels/agent.js";
 
@@ -11,25 +10,38 @@ export class BaseSearchWebAgentWithAi extends PolicySynthAgent {
     super(agent, memory, 0, 100);
   }
 
-  async callSearchApi(query: string, numberOfResults: number): Promise<PsSearchResultItem[]> {
+  async callSearchApi(
+    query: string,
+    numberOfResults: number,
+    options: PsSearchOptions = {}
+  ): Promise<PsSearchResultItem[]> {
     if (process.env.GOOGLE_SEARCH_API_KEY &&
         process.env.GOOGLE_SEARCH_API_CX_ID) {
         const googleSearchApi = new GoogleSearchApi();
-        return await googleSearchApi.search(query, numberOfResults);
+        return await googleSearchApi.search(query, numberOfResults, options);
     } else if (process.env.AZURE_BING_SEARCH_KEY) {
       const bingSearchApi = new BingSearchApi();
-      return await bingSearchApi.search(query, numberOfResults);
+      return await bingSearchApi.search(query, numberOfResults, options);
     } else {
       this.logger.error("Missing search API key");
       throw new Error("Missing search API key");
     }
   }
 
-  async getQueryResults(queriesToSearch: string[], id: string, numberOfResults: number = 10) {
+  async getQueryResults(
+    queriesToSearch: string[],
+    id: string,
+    numberOfResults: number = 10,
+    options: PsSearchOptions = {}
+  ) {
     let searchResults: PsSearchResultItem[] = [];
 
     for (let q = 0; q < queriesToSearch.length; q++) {
-      const generalSearchData = await this.callSearchApi(queriesToSearch[q], numberOfResults);
+      const generalSearchData = await this.callSearchApi(
+        queriesToSearch[q],
+        numberOfResults,
+        options
+      );
 
       this.logger.debug(
         `Got Search Data 1: ${JSON.stringify(generalSearchData, null, 2)}`


### PR DESCRIPTION
## Summary
- add `PsSearchOptions` interface for before/after date queries
- update Google and Bing search APIs to accept optional options
- allow BaseSearchWebAgent and BaseSearchWebAgentWithAi to pass options
- document new parameters in search API docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68520dca338c832e9f6790081386bdaf