### PR TITLE
Add date range search options

### DIFF
--- a/agents/docs/src/webResearch/bingSearchApi.md
+++ b/agents/docs/src/webResearch/bingSearchApi.md
@@ -26,7 +26,7 @@ Performs a search query using the Bing Search API and returns the search results
 
 - `query` (string): The search query string.
 - `numberOfResults` (number): The number of search results to retrieve. The Bing API allows specifying a count up to a certain limit (commonly 50).
-- `options?` (`PsSearchOptions`): Optional search modifiers such as `before` or `after` dates.
+- `options?` (`PsSearchOptions`): Optional modifiers like `dateRestrict` or `sort` for time filtering. `before` and `after` remain supported.
 
 #### Return Type
 
@@ -38,7 +38,7 @@ Performs a search query using the Bing Search API and returns the search results
 import { BingSearchApi } from '@policysynth/agents/webResearch/bingSearchApi.js';
 
 const bingSearch = new BingSearchApi();
-bingSearch.search("example query", 10, { before: "2024/01/01" })
+bingSearch.search("example query", 10, { dateRestrict: "d7" })
   .then(results => {
     console.log(results);
   })

--- a/agents/docs/src/webResearch/googleSearchApi.md
+++ b/agents/docs/src/webResearch/googleSearchApi.md
@@ -20,7 +20,7 @@ The `GoogleSearchApi` class is a specialized agent that extends the `PolicySynth
 
 - `query: string`: The search query string.
 - `numberOfResults: number`: The number of search results to retrieve.
-- `options?: PsSearchOptions`: Optional search modifiers such as `before` or `after` dates.
+- `options?: PsSearchOptions`: Optional search modifiers. Use `dateRestrict` for relative windows (e.g. `d7`) or `sort` with `date:r:YYYYMMDD:YYYYMMDD` for absolute ranges. Legacy `before` and `after` parameters are still supported.
 
 #### Returns
 
@@ -41,7 +41,7 @@ async function exampleUsage() {
     const results = await googleSearchApi.search(
       "liberal democracies: issues and solutions",
       20,
-      { after: "2024/01/01" }
+      { dateRestrict: "d7" }
     );
     console.log("Search results:", results);
   } catch (error) {

--- a/agents/docs/src/webResearch/searchWeb.md
+++ b/agents/docs/src/webResearch/searchWeb.md
@@ -35,7 +35,7 @@ This method determines which search API to use based on the environment variable
 - **Parameters:**
   - `query`: The search query string.
   - `numberOfResults`: The number of search results to retrieve.
-  - `options?`: Optional `PsSearchOptions` with `before` or `after` date filters.
+  - `options?`: Optional `PsSearchOptions` allowing time filters via `dateRestrict` or `sort` (legacy `before` and `after` supported).
 
 - **Returns:** A promise that resolves to an array of `PsSearchResultItem` containing the search results.
 

--- a/agents/docs/src/webResearch/searchWebWithAi.md
+++ b/agents/docs/src/webResearch/searchWebWithAi.md
@@ -29,7 +29,7 @@ Performs a search using either the Google Search API or the Bing Search API, dep
 
 - `query`: `string` - The search query.
 - `numberOfResults`: `number` - The number of results to fetch.
-- `options?`: `PsSearchOptions` - Optional modifiers such as `before` or `after` dates.
+- `options?`: `PsSearchOptions` - Optional modifiers like `dateRestrict` or `sort` for time filtering. `before` and `after` are still accepted.
 
 #### Returns
 
@@ -66,7 +66,7 @@ const searchAgent = new BaseSearchWebAgentWithAi(agent, memory);
 
 const queries = ["example query 1", "example query 2"];
 const results = await searchAgent.getQueryResults(queries, "uniqueId", 10, {
-  before: "2024/01/01"
+  dateRestrict: "d7"
 });
 
 console.log(results.searchResults);

--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -209,6 +209,16 @@ type SearchResultItem = PsSearchResultItem[];
 interface PsSearchOptions {
   before?: string;
   after?: string;
+  /**
+   * Relative date restriction like `d7` for last 7 days
+   * according to Google Custom Search API `dateRestrict` parameter.
+   */
+  dateRestrict?: string;
+  /**
+   * Absolute date range in the format `date:r:YYYYMMDD:YYYYMMDD`
+   * used with the Google Custom Search API `sort` parameter.
+   */
+  sort?: string;
 }
 
 interface PsAgentBaseMemoryData {

--- a/agents/src/deepResearch/bingSearchApi.ts
+++ b/agents/src/deepResearch/bingSearchApi.ts
@@ -25,14 +25,26 @@ export class BingSearchApi extends PolicySynthSimpleAgentBase {
     if (options.after) {
       finalQuery += ` after:${options.after}`;
     }
+    const extraParams: string[] = [];
+    if (options.dateRestrict) {
+      extraParams.push(`dateRestrict=${encodeURIComponent(options.dateRestrict)}`);
+    }
+    if (options.sort) {
+      extraParams.push(`sort=${encodeURIComponent(options.sort)}`);
+    }
     // Bing API allows specifying count up to a certain limit (commonly 50)
     // For simplicity, we assume numberOfResults <= 50. If needed, multiple calls could be implemented similarly to Google.
     const maxBingResults = numberOfResults > 50 ? 50 : numberOfResults;
+    let url =
+      `https://api.cognitive.microsoft.com/bing/v7.0/search?count=${maxBingResults}&q=` +
+      encodeURIComponent(finalQuery);
+    if (extraParams.length > 0) {
+      url += `&${extraParams.join("&")}`;
+    }
+
     const requestParams: AxiosRequestConfig = {
       method: "GET",
-      url:
-        `https://api.cognitive.microsoft.com/bing/v7.0/search?count=${maxBingResults}&q=` +
-        encodeURIComponent(finalQuery),
+      url,
       headers: {
         "Ocp-Apim-Subscription-Key": this.SUBSCRIPTION_KEY!,
       },

--- a/agents/src/deepResearch/googleSearchApi.ts
+++ b/agents/src/deepResearch/googleSearchApi.ts
@@ -52,6 +52,14 @@ export class GoogleSearchApi extends PolicySynthSimpleAgentBase {
     if (options.after) {
       finalQuery += ` after:${options.after}`;
     }
+
+    const extraParams: string[] = [];
+    if (options.dateRestrict) {
+      extraParams.push(`dateRestrict=${encodeURIComponent(options.dateRestrict)}`);
+    }
+    if (options.sort) {
+      extraParams.push(`sort=${encodeURIComponent(options.sort)}`);
+    }
     const outResults: PsSearchResultItem[] = [];
     const maxPerRequest = 10;
 
@@ -65,11 +73,15 @@ export class GoogleSearchApi extends PolicySynthSimpleAgentBase {
         numberOfResults - outResults.length
       );
 
-      const url = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(
+      let url = `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(
         finalQuery
       )}&key=${process.env.GOOGLE_SEARCH_API_KEY}&cx=${
         process.env.GOOGLE_SEARCH_API_CX_ID
       }&num=${resultsToFetch}&start=${startIndex}`;
+
+      if (extraParams.length > 0) {
+        url += `&${extraParams.join("&")}`;
+      }
 
       try {
         // Use our custom requestWithRetry wrapper


### PR DESCRIPTION
## Summary
- support `dateRestrict` and `sort` in search options
- include new date range params in Google and Bing search APIs
- document date filter options

## Testing
- `npm run build` in `agents/`

------
https://chatgpt.com/codex/tasks/task_e_68521530a1c8832eaa90c64de5b6aba3