### PR TITLE
Improve mobile layout for Eric Chatbot

### DIFF
--- a/projects/ecasEric/webApp/src/base/ps-chat-assistant.ts
+++ b/projects/ecasEric/webApp/src/base/ps-chat-assistant.ts
@@ -701,6 +701,14 @@ export class PsChatAssistant extends PsStreamingLlmBase {
           background-color: #fff3f2;
         }
 
+        @media (max-width: 600px) {
+          md-outlined-text-field {
+            width: 100%;
+            margin-left: 0;
+            margin-right: 0;
+          }
+        }
+
         @media (max-width: 960px) {
           .restartButton {
             margin-left: 8px;

--- a/projects/ecasEric/webApp/src/base/ps-input-dialog.ts
+++ b/projects/ecasEric/webApp/src/base/ps-input-dialog.ts
@@ -175,6 +175,12 @@ export class PsInputDialog extends YpBaseElement {
           transition: opacity 0.3s;
         }
 
+        @media (max-width: 600px) {
+          .chatInput {
+            width: 100%;
+          }
+        }
+
         .chatInput.is-disabled {
           opacity: 0.8;
         }

--- a/projects/ecasEric/webApp/src/base/ps-input-textarea.ts
+++ b/projects/ecasEric/webApp/src/base/ps-input-textarea.ts
@@ -27,6 +27,14 @@ export class PsInputTextArea extends LitElement {
       line-height: 1.25;
     }
 
+    @media (max-width: 600px) {
+      .textarea {
+        width: 100%;
+        max-width: 100%;
+        margin-left: 0;
+      }
+    }
+
     .textarea::placeholder {
       color: #111;
     }

--- a/projects/ecasEric/webApp/src/eric-app.ts
+++ b/projects/ecasEric/webApp/src/eric-app.ts
@@ -184,6 +184,12 @@ export class EcasYeaChatBotApp extends PolicySynthWebApp {
           max-width: 1000px;
         }
 
+        @media (max-width: 600px) {
+          eric-chat-bot {
+            max-width: 100%;
+          }
+        }
+
         .ecasTopLeft {
           font-size: 16px;
           color: #1d42d9;

--- a/projects/ecasEric/webApp/src/eric-chatbot.ts
+++ b/projects/ecasEric/webApp/src/eric-chatbot.ts
@@ -61,6 +61,12 @@ export class EcasEricChatBot extends PsChatAssistant {
           height: 78vh;
           width: 1000px;
         }
+
+        @media (max-width: 600px) {
+          .chat-window {
+            width: 100%;
+          }
+        }
       `,
     ];
   }


### PR DESCRIPTION
## Summary
- add responsive width for the main chat window
- allow chatbot component to shrink on small screens
- make dialog and textarea inputs scale to device width
- ensure chat input field expands correctly on phones

## Testing
- `npx tsc -p projects/ecasEric/webApp/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68547ff8ee48832e8e1c12ce7e61cc30