### PR TITLE
Fix send button in ECAS web app

### DIFF
--- a/projects/ecasEric/webApp/src/base/ps-chat-assistant.ts
+++ b/projects/ecasEric/webApp/src/base/ps-chat-assistant.ts
@@ -448,6 +448,10 @@ export class PsChatAssistant extends PsStreamingLlmBase {
     this.sendChatMessage();
   }
 
+  handleSendMessage(_event: CustomEvent) {
+    this.sendChatMessage();
+  }
+
   reset() {
     this.chatLog = [];
     // Let the base class handle closing & resetting
@@ -494,6 +498,7 @@ export class PsChatAssistant extends PsStreamingLlmBase {
           hasTrailingIcon
           id="chatInput"
           rows="5"
+          @send-message="${this.handleSendMessage}"
           @keyup="${(e: KeyboardEvent) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();

--- a/projects/ecasEric/webApp/src/base/ps-input-dialog.ts
+++ b/projects/ecasEric/webApp/src/base/ps-input-dialog.ts
@@ -136,6 +136,10 @@ export class PsInputDialog extends YpBaseElement {
     this.isDisabled = true;
 
     this._chatTextarea?.clear();
+
+    if (messageText.length > 0) {
+      this.fire("send-message", { message: messageText });
+    }
   }
 
   private _onStopWorkflow() {


### PR DESCRIPTION
## Summary
- fire a `send-message` event from `<ps-input-dialog>` when clicking the Send button
- listen for the `send-message` event in `<ps-chat-assistant>` and forward to `sendChatMessage`

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68548940b670832eae61d9ea82412553