### PR TITLE
Add GA4 tags with cookie consent overlay

### DIFF
--- a/projects/ecasEric/webApp/index.html
+++ b/projects/ecasEric/webApp/index.html
@@ -59,6 +59,26 @@
       href="https://ecas.org/favicon-32x32.png"
     />
 
+    <!-- Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      if (localStorage.getItem('ga_consent') === 'granted') {
+        gtag('consent', 'update', { analytics_storage: 'granted' });
+      } else {
+        window['ga-disable-G-XXXXXXXXXX'] = true;
+        gtag('consent', 'update', { analytics_storage: 'denied' });
+      }
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
+
     <base href="/" />
 
     <style>
@@ -87,7 +107,9 @@
 
   <body>
     <eric-chatbot-app></eric-chatbot-app>
+    <cookie-consent></cookie-consent>
     <script type="module" src="./ts-out/src/eric-app.js"></script>
+    <script type="module" src="./ts-out/src/cookie-consent.js"></script>
     <script type="module">
       if (!window.ElementInternals) {
         import("./node_modules/element-internals-polyfill/dist/index.js");

--- a/projects/ecasEric/webApp/src/cookie-consent.ts
+++ b/projects/ecasEric/webApp/src/cookie-consent.ts
@@ -1,0 +1,99 @@
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import '@material/web/button/filled-button.js';
+import '@material/web/button/text-button.js';
+
+@customElement('cookie-consent')
+export class CookieConsent extends LitElement {
+  @state()
+  private visible = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    const consent = localStorage.getItem('ga_consent');
+    this.visible = consent === null;
+  }
+
+  private updateAnalytics(granted: boolean) {
+    const gaId = 'G-XXXXXXXXXX';
+    (window as any)['ga-disable-' + gaId] = !granted;
+    if (typeof (window as any).gtag === 'function') {
+      (window as any).gtag('consent', 'update', {
+        analytics_storage: granted ? 'granted' : 'denied',
+      });
+    }
+  }
+
+  private accept() {
+    localStorage.setItem('ga_consent', 'granted');
+    this.updateAnalytics(true);
+    this.visible = false;
+  }
+
+  private deny() {
+    localStorage.setItem('ga_consent', 'denied');
+    this.updateAnalytics(false);
+    this.visible = false;
+  }
+
+  static styles = css`
+    :host {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 1000;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 16px;
+      background-color: var(--md-sys-color-surface, #ffffff);
+      color: var(--md-sys-color-on-surface, #000000);
+      box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.2);
+      font-size: 14px;
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
+
+    @media (min-width: 600px) {
+      :host {
+        flex-direction: row;
+        align-items: center;
+      }
+      .text {
+        flex: 1;
+      }
+    }
+  `;
+
+  render() {
+    if (!this.visible) {
+      return nothing;
+    }
+    return html`
+      <span class="text"
+        >To provide the best experiences, we use technologies like cookies to
+        store and/or access device information. Giving your consent allows us to
+        process data such as browsing behaviour or unique IDs on this site. Not
+        consenting or withdrawing consent may affect certain features and
+        functions.</span
+      >
+      <div class="actions">
+        <md-filled-button @click=${this.accept}>Accept</md-filled-button>
+        <md-text-button @click=${this.deny}>Deny</md-text-button>
+        <a href="/cookie-policy" target="_blank">Cookie Policy</a>
+        <a href="/privacy-policy" target="_blank">Privacy Policy</a>
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate Google Analytics v4 with consent check in `index.html`
- implement `<cookie-consent>` overlay that toggles analytics based on user choice
- include GA consent logic for Accept/Deny actions

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68549378f764832ea6195fdf751c6162