### PR TITLE
Add Sub Agents Connector

### DIFF
--- a/agents/docs/src/connectors/agents/subAgentsConnector.md
+++ b/agents/docs/src/connectors/agents/subAgentsConnector.md
@@ -1,0 +1,4 @@
+# PsSubAgentsConnector
+
+The `PsSubAgentsConnector` class allows linking multiple agents together using the existing input and output connector framework. It extends `PsBaseConnector` and provides helper methods to list all agents connected to the connector on both the input and output side.
+

--- a/agents/src/connectorTypes.ts
+++ b/agents/src/connectorTypes.ts
@@ -5,5 +5,6 @@ export enum PsConnectorClassTypes {
   IdeasCollaboration = "ideasCollaboration",
   VotingCollaboration = "votingCollaboration",
   Drive = "drive",
+  SubAgents = "subAgents",
 }
 

--- a/agents/src/connectors/agents/subAgentsConnector.ts
+++ b/agents/src/connectors/agents/subAgentsConnector.ts
@@ -1,0 +1,72 @@
+import { PsBaseConnector } from "../base/baseConnector.js";
+import { PsConnectorClassTypes } from "../../connectorTypes.js";
+import { PsAgent } from "../../dbModels/agent.js";
+import { PsAgentConnector } from "../../dbModels/agentConnector.js";
+
+export class PsSubAgentsConnector extends PsBaseConnector {
+  static readonly SUB_AGENTS_CONNECTOR_CLASS_BASE_ID =
+    "0d0d0d0d-0000-0000-0000-000000000000";
+
+  static readonly SUB_AGENTS_CONNECTOR_VERSION = 1;
+
+  static getConnectorClass: PsAgentConnectorClassCreationAttributes = {
+    class_base_id: this.SUB_AGENTS_CONNECTOR_CLASS_BASE_ID,
+    name: "Sub Agents Connector",
+    version: this.SUB_AGENTS_CONNECTOR_VERSION,
+    user_id: 1,
+    available: true,
+    configuration: {
+      name: "Sub Agents Connector",
+      classType: PsConnectorClassTypes.SubAgents,
+      description: "Connector for linking agents together",
+      hasPublicAccess: true,
+      imageUrl: "",
+      iconName: "agents",
+      questions: [
+        { uniqueId: "name", text: "Name", type: "textField", maxLength: 200, required: true },
+        { uniqueId: "description", text: "Description", type: "textArea", maxLength: 500, required: false },
+      ],
+    },
+  };
+
+  constructor(
+    connector: PsAgentConnectorAttributes,
+    connectorClass: PsAgentConnectorClassAttributes,
+    agent: PsAgent,
+    memory: PsAgentMemoryData | undefined = undefined,
+    startProgress: number = 0,
+    endProgress: number = 100
+  ) {
+    super(connector, connectorClass, agent, memory, startProgress, endProgress);
+  }
+
+  async listConnectedInputAgents(): Promise<PsAgent[]> {
+    if (!(this.connector as any).id) return [];
+    return await PsAgent.findAll({
+      include: [
+        {
+          model: PsAgentConnector,
+          as: "InputConnectors",
+          where: { id: (this.connector as any).id },
+          attributes: [],
+          through: { attributes: [] },
+        },
+      ],
+    });
+  }
+
+  async listConnectedOutputAgents(): Promise<PsAgent[]> {
+    if (!(this.connector as any).id) return [];
+    return await PsAgent.findAll({
+      include: [
+        {
+          model: PsAgentConnector,
+          as: "OutputConnectors",
+          where: { id: (this.connector as any).id },
+          attributes: [],
+          through: { attributes: [] },
+        },
+      ],
+    });
+  }
+}

--- a/agents/src/connectors/base/connectorFactory.ts
+++ b/agents/src/connectors/base/connectorFactory.ts
@@ -12,6 +12,7 @@ import { PsYourPrioritiesConnector } from "../collaboration/yourPrioritiesConnec
 import { PsGoogleSheetsConnector } from "../sheets/googleSheetsConnector.js";
 import { PsBaseSheetConnector } from "./baseSheetConnector.js";
 import { PsAllOurIdeasConnector } from "../collaboration/allOurIdeasConnector.js";
+import { PsSubAgentsConnector } from "../agents/subAgentsConnector.js";
 import { PolicySynthAgentBase } from "../../base/agentBase.js";
 //import { PsGitHubConnector } from "../collaboration/gitHubConnector.js";
 
@@ -20,7 +21,8 @@ type PsBaseConnectorTypes =
   | PsBaseSheetConnector
   | PsBaseNotificationsConnector
   | PsBaseVotingCollaborationConnector
-  | PsBaseIdeasCollaborationConnector;
+  | PsBaseIdeasCollaborationConnector
+  | PsSubAgentsConnector;
 
 export class PsConnectorFactory extends PolicySynthAgentBase {
   static createConnector(
@@ -64,6 +66,14 @@ export class PsConnectorFactory extends PolicySynthAgentBase {
 
       case PsConnectorClassTypes.VotingCollaboration:
         return this.createVotingCollaborationConnector(
+          connector,
+          connectorClass,
+          agent,
+          memory
+        );
+
+      case PsConnectorClassTypes.SubAgents:
+        return this.createSubAgentsConnector(
           connector,
           connectorClass,
           agent,
@@ -208,6 +218,20 @@ export class PsConnectorFactory extends PolicySynthAgentBase {
         );
         return null;
     }
+  }
+
+  static createSubAgentsConnector(
+    connector: PsAgentConnectorAttributes,
+    connectorClass: PsAgentConnectorClassAttributes,
+    agent: PsAgent,
+    memory: any
+  ): PsSubAgentsConnector {
+    return new PsSubAgentsConnector(
+      connector,
+      connectorClass,
+      agent,
+      memory
+    );
   }
 
   static getConnector(


### PR DESCRIPTION
## Summary
- support a new connector type `SubAgents`
- implement `PsSubAgentsConnector` for linking agents together
- enable factory creation of this connector
- document the new connector

## Testing
- `npm run build` in `agents/`

------
https://chatgpt.com/codex/tasks/task_e_6857ed518db8832e9a7bf8c8e8753715