### PR TITLE
Fix token limit error loops

### DIFF
--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -55,6 +55,12 @@ interface PsCallModelOptions {
     mimeType: string;
     data: string;
   }[];
+  /**
+   * When true, token limit errors will be rethrown instead of triggering
+   * the TokenLimitChunker retry logic. Useful for preventing infinite
+   * retry loops if chunking already failed.
+   */
+  disableChunkingRetry?: boolean;
 }
 
 interface PsAzureAiModelConfig extends PsAiModelConfig {

--- a/agents/src/base/agentModelManager.ts
+++ b/agents/src/base/agentModelManager.ts
@@ -698,6 +698,12 @@ export class PsAiModelManager extends PolicySynthAgentBase {
           continue;
         }
         if (TokenLimitChunker.isTokenLimitError(error)) {
+          if (options.disableChunkingRetry) {
+            this.logger.warn(
+              "Token limit error encountered after chunking; giving up."
+            );
+            throw error;
+          }
           this.logger.warn("Token limit exceeded, invoking chunking handler");
           const handler = new TokenLimitChunker(this);
           return await handler.handle(


### PR DESCRIPTION
## Summary
- add `disableChunkingRetry` option so token chunker errors don't recurse
- stop retrying when token limit errors occur after chunking
- ensure chunker passes disable flag and logs failures

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68581d43954c832e9508052621ffd3a0