### PR TITLE
Modify nginx config to disable index caching

### DIFF
--- a/projects/ecasEric/webApi/docker/webserver/nginx.conf
+++ b/projects/ecasEric/webApi/docker/webserver/nginx.conf
@@ -73,6 +73,11 @@ http {
       try_files $uri $uri/ /index.html;
     }
 
+    # Disable caching for the SPA entry point
+    location = /index.html {
+      add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+    }
+
     location ^~ /public/storage/ {
       expires 365d;
       add_header Cache-Control "public";


### PR DESCRIPTION
## Summary
- add specific location for index.html to disable caching in `nginx.conf`

## Testing
- `npx tsc -p projects/ecasEric/webApi`

------
https://chatgpt.com/codex/tasks/task_e_685896e48c64832e99f36c47782ad208