### PR TITLE
Add Gemini API key env var

### DIFF
--- a/agents/docs/src/aiModels/googleGeminiChat.md
+++ b/agents/docs/src/aiModels/googleGeminiChat.md
@@ -98,6 +98,7 @@ const messages = [
   - `USE_GOOGLE_VERTEX_AI` (set to `"true"` to use Vertex AI for all models)
   - `USE_GOOGLE_VERTEX_AI_FOR_MODELS` (comma-separated list of model names to use Vertex AI for)
   - `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are required for Vertex AI.
+- The environment variable `PS_AGENT_GEMINI_API_KEY` overrides `config.apiKey` when using the Google Generative AI API.
 - Safety settings are set to "block none" for all harm categories by default.
 - Token usage is tracked and can be logged for debugging/cost analysis.
 - The `generate` method supports both streaming and non-streaming completions.

--- a/agents/src/aiModels/googleGeminiChat.ts
+++ b/agents/src/aiModels/googleGeminiChat.ts
@@ -65,12 +65,19 @@ export class GoogleGeminiChat extends BaseChatModel {
       });
       this.logger.info("Using Google Cloud Vertex AI");
     } else {
-      if (!config.apiKey) {
+      let apiKey = config.apiKey;
+      if (process.env.PS_AGENT_GEMINI_API_KEY) {
+        apiKey = process.env.PS_AGENT_GEMINI_API_KEY;
+        this.logger.debug(
+          "Using Google Gemini API key from PS_AGENT_GEMINI_API_KEY environment variable"
+        );
+      }
+      if (!apiKey) {
         throw new Error(
           "Google Generative AI requires an API key. Provide it in config.apiKey."
         );
       }
-      this.googleAiClient = new GoogleGenerativeAI(config.apiKey);
+      this.googleAiClient = new GoogleGenerativeAI(apiKey);
       this.logger.info("Using Google Generative AI API");
     }
   }


### PR DESCRIPTION
## Summary
- allow Gemini API key override via PS_AGENT_GEMINI_API_KEY
- document PS_AGENT_GEMINI_API_KEY in Gemini model docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a3878c6ac832e866c1c2b4ef0286a