### PR TITLE
Add error ignore list for Airbrake logger

### DIFF
--- a/agents/src/base/agentBase.ts
+++ b/agents/src/base/agentBase.ts
@@ -21,12 +21,16 @@ export class PolicySynthAgentBase {
     ];
 
     if (process.env.AIRBRAKE_PROJECT_ID && process.env.AIRBRAKE_PROJECT_KEY) {
+      const ignored = process.env.AIRBRAKE_IGNORED_ERRORS
+        ? process.env.AIRBRAKE_IGNORED_ERRORS.split(',').map((e) => e.trim()).filter(Boolean)
+        : [];
       transports.push(
         new AirbrakeTransport({
           level: "error",
           projectId: +process.env.AIRBRAKE_PROJECT_ID,
           projectKey: process.env.AIRBRAKE_PROJECT_KEY,
           environment: process.env.NODE_ENV,
+          ignoredErrorMessages: ignored,
         })
       );
     }


### PR DESCRIPTION
## Summary
- allow winstonAirbrake transport to ignore certain error messages
- read `AIRBRAKE_IGNORED_ERRORS` env var to configure ignore list

## Testing
- `npm run build` in `agents/`

------
https://chatgpt.com/codex/tasks/task_e_685d33afd42c832e95ab629ea7c78d98