### PR TITLE
Fix context token limit load

### DIFF
--- a/agents/src/base/agentModelManager.ts
+++ b/agents/src/base/agentModelManager.ts
@@ -184,6 +184,7 @@ export class PsAiModelManager extends PolicySynthAgentBase {
         apiKey: apiKeyConfig.apiKey,
         modelName: model.configuration.model,
         maxTokensOut: this.maxTokensOut,
+        maxContextTokens: model.configuration.maxContextTokens,
         temperature: this.modelTemperature,
         reasoningEffort: this.reasoningEffort,
         maxThinkingTokens: this.maxThinkingTokens,


### PR DESCRIPTION
## Summary
- set `maxContextTokens` from the database when initializing models

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868460d514c832e8c55f6b9d52474ad