### PR TITLE
Add custom XML tag support for TokenLimitChunker

### DIFF
--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -61,6 +61,12 @@ interface PsCallModelOptions {
    * retry loops if chunking already failed.
    */
   disableChunkingRetry?: boolean;
+  /**
+   * Optional XML tag name to preserve when the TokenLimitChunker needs to split
+   * a document due to token limits. If provided, the chunker will search for
+   * this tag instead of blindly grabbing the first XML tag in the message.
+   */
+  xmlTagToPreserveForTooManyTokenSplitting?: string;
 }
 
 interface PsAzureAiModelConfig extends PsAiModelConfig {

--- a/agents/src/base/tokenLimitChunker.ts
+++ b/agents/src/base/tokenLimitChunker.ts
@@ -294,7 +294,11 @@ export class TokenLimitChunker extends PolicySynthAgentBase {
     /* ---------------------------------------------------------
      * 3. Slice document into chunks.
      * ------------------------------------------------------- */
-    const firstTagMatch = docMessage.message.match(/<[^>]+>/);
+    const tagName = options.xmlTagToPreserveForTooManyTokenSplitting;
+    const tagRegex = tagName
+      ? new RegExp(`<${tagName}[^>]*>`, "i")
+      : /<[^>]+>/;
+    const firstTagMatch = docMessage.message.match(tagRegex);
     const firstTag = firstTagMatch ? firstTagMatch[0] : "";
     const bodyWithoutTag = firstTag
       ? docMessage.message.replace(firstTag, "")


### PR DESCRIPTION
## Summary
- extend `PsCallModelOptions` with `xmlTagToPreserveForTooManyTokenSplitting`
- use the provided tag in `TokenLimitChunker` when splitting prompts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868f45ec7b8832e971da67113b7bfd2