### PR TITLE
Fix XML block capture in TokenLimitChunker

### DIFF
--- a/agents/src/base/tokenLimitChunker.ts
+++ b/agents/src/base/tokenLimitChunker.ts
@@ -272,7 +272,12 @@ export class TokenLimitChunker extends PolicySynthAgentBase {
      * 3. Slice document into chunks.
      * ------------------------------------------------------- */
     const tagName = options.xmlTagToPreserveForTooManyTokenSplitting;
-    const tagRegex = tagName ? new RegExp(`<${tagName}[^>]*>`, "i") : /<[^>]+>/;
+    const tagRegex = tagName
+      ? new RegExp(
+          `<${tagName}[^>]*>[\\s\\S]*?<\\/${tagName}>`,
+          "i"
+        )
+      : /<[^>]+>/;
     const tagMatch = docMessage.message.match(tagRegex);
     const lastTag = tagMatch ? tagMatch[0] : "";
     let bodyWithoutTag = lastTag


### PR DESCRIPTION
## Summary
- handle entire XML block instead of just the opening tag when splitting documents in `TokenLimitChunker`
- this ensures nested tags are preserved for `<UserData>` and other tags

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68690c03cadc832e93ca0df1385e447c