### PR TITLE
Limit token splitter chunks

### DIFF
--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -73,6 +73,13 @@ interface PsCallModelOptions {
    * Defaults to 50 words if not provided.
    */
   numberOfLastWordsToPreserveForTooManyTokenSplitting?: number;
+  /**
+   * Maximum number of document chunks allowed when the TokenLimitChunker
+   * splits a document due to token limits. Defaults to 10. If the
+   * chunker needs to create more chunks than this value an error will be
+   * thrown to prevent excessive costs.
+   */
+  maximumNumberOfSplitDocumentChunks?: number;
 }
 
 interface PsAzureAiModelConfig extends PsAiModelConfig {

--- a/agents/src/base/agent.ts
+++ b/agents/src/base/agent.ts
@@ -152,7 +152,8 @@ export abstract class PolicySynthAgent extends PolicySynthAgentBase {
       limitedRetries: false,
       tokenOutEstimate: 1200,
       streamingCallbacks: undefined,
-      numberOfLastWordsToPreserveForTooManyTokenSplitting: 50
+      numberOfLastWordsToPreserveForTooManyTokenSplitting: 50,
+      maximumNumberOfSplitDocumentChunks: 10
     }
   ) {
     return this.modelManager?.callModel(

--- a/agents/src/base/agentPairwiseRanking.ts
+++ b/agents/src/base/agentPairwiseRanking.ts
@@ -142,7 +142,8 @@ export abstract class PairwiseRankingAgent extends PolicySynthAgent {
     itemTwoIndex: number,
     modelOptions: PsCallModelOptions = {
       parseJson: false,
-      numberOfLastWordsToPreserveForTooManyTokenSplitting: 50
+      numberOfLastWordsToPreserveForTooManyTokenSplitting: 50,
+      maximumNumberOfSplitDocumentChunks: 10
     }
   ): Promise<PsPairWiseVoteResults> {
     let wonItemIndex: number = -1;

--- a/agents/src/base/agentStandalone.ts
+++ b/agents/src/base/agentStandalone.ts
@@ -93,7 +93,8 @@ export class PolicySynthStandaloneAgent extends PolicySynthAgentBase {
       limitedRetries: false,
       tokenOutEstimate: 120,
       streamingCallbacks: undefined,
-      numberOfLastWordsToPreserveForTooManyTokenSplitting: 50
+      numberOfLastWordsToPreserveForTooManyTokenSplitting: 50,
+      maximumNumberOfSplitDocumentChunks: 10
     }
   ): Promise<any> {
     return this.modelManager.callModel(

--- a/agents/src/base/tokenLimitChunker.ts
+++ b/agents/src/base/tokenLimitChunker.ts
@@ -360,6 +360,14 @@ export class TokenLimitChunker extends PolicySynthAgentBase {
       allowedPerChunkWithTag
     );
 
+    const maxChunksAllowed =
+      options.maximumNumberOfSplitDocumentChunks ?? 10;
+    if (chunks.length > maxChunksAllowed) {
+      throw new Error(
+        `TokenLimitChunker: Document requires ${chunks.length} chunks which exceeds the allowed maximum of ${maxChunksAllowed}.`
+      );
+    }
+
     const concurrency = 32;
     const limit = pLimit(concurrency);
 


### PR DESCRIPTION
## Summary
- define `maximumNumberOfSplitDocumentChunks` call option
- use new option in `TokenLimitChunker`
- apply default of 10 chunks in agent classes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e9069ac00832ebfbeae7ef9462087