### PR TITLE
Add job title degree extraction

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/types.d.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/types.d.ts
@@ -64,6 +64,7 @@ interface JobDescriptionMemoryData extends PsAgentMemoryData {
   researchPlan?: string;
   educationRequirementResearchResults?: import("../legalResearch/types.js").EducationRequirementResearchRow[];
   statuteResearch?: import("../legalResearch/types.js").StatuteResearchMemory;
+  extractedJobTitleDegreeInformation?: import("../legalResearch/types.js").ExtractedJobTitleInformation[];
 }
 
 /**

--- a/projects/skillsFirst/agents/src/legalResearch/types.d.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/types.d.ts
@@ -32,3 +32,8 @@ interface StatuteResearchMemory {
   chunks: StatuteChunkAnalysis[];
   jobMatches: { [jobTitle: string]: JobStatuteMatchResult[] };
 }
+interface ExtractedJobTitleInformation {
+  title: string;
+  chunkIndex: number;
+  extractedJobTitleDegreeInformation: string[];
+}


### PR DESCRIPTION
## Summary
- rename memory field to `extractedJobTitleDegreeInformation`
- capture degree requirement mentions with text reasoning model
- update types for extracted job title data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68793ecf679c832e966ad8aeeff93007