### PR TITLE
Add legal research result fields to job degree analysis

### DIFF
--- a/projects/skillsFirst/agents/src/legalResearch/educationRequirementsBarrierDeepResearchAgent.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/educationRequirementsBarrierDeepResearchAgent.ts
@@ -53,10 +53,22 @@ export class EducationRequirementsBarrierDeepResearchAgent extends PolicySynthAg
           100
         );
         const urls = await finder.findSources(job.name);
-        const { results: statuteResults, educationRequirementResults } = await statutesAgent.analyseJob(job.name);
+        const { results: statuteResults, educationRequirementResults } =
+          await statutesAgent.analyseJob(job.name);
 
         if (educationRequirementResults.length > 0) {
           results.push(...educationRequirementResults);
+          job.degreeAnalysis.deepResearchResults =
+            job.degreeAnalysis.deepResearchResults || [];
+          job.degreeAnalysis.deepResearchResults.push(
+            ...educationRequirementResults,
+          );
+        }
+
+        if (statuteResults.length > 0) {
+          job.degreeAnalysis.statutesResearchResults =
+            job.degreeAnalysis.statutesResearchResults || [];
+          job.degreeAnalysis.statutesResearchResults.push(...statuteResults);
         }
 
         const finalUrls = Array.from(new Set(urls)).slice(0, 3);
@@ -95,6 +107,9 @@ export class EducationRequirementsBarrierDeepResearchAgent extends PolicySynthAg
             res.sourceUrl = page.url;
             if (!("error" in res)) {
               results.push(res);
+              job.degreeAnalysis.deepResearchResults =
+                job.degreeAnalysis.deepResearchResults || [];
+              job.degreeAnalysis.deepResearchResults.push(res);
             }
           }
         }

--- a/projects/skillsFirst/agents/src/types.d.ts
+++ b/projects/skillsFirst/agents/src/types.d.ts
@@ -97,6 +97,8 @@ interface JobDescriptionDegreeAnalysis {
   // From the last question:
   // "Identify any barrier or obstacle stated, suggested, or described in the job description to hiring an applicant who does not have a college or university degree.
   // If there are no barriers, leave the field blank. Do not fabricate any information."
+  deepResearchResults?: import("../legalResearch/types.js").EducationRequirementResearchResult[];
+  statutesResearchResults?: import("../legalResearch/types.js").JobStatuteMatchResult[];
 }
 
 /**
@@ -215,6 +217,8 @@ interface JobDescriptionDegreeAnalysis {
   // From the last question:
   // "Identify any barrier or obstacle stated, suggested, or described in the job description to hiring an applicant who does not have a college or university degree.
   // If there are no barriers, leave the field blank. Do not fabricate any information."
+  deepResearchResults?: import("../legalResearch/types.js").EducationRequirementResearchResult[];
+  statutesResearchResults?: import("../legalResearch/types.js").JobStatuteMatchResult[];
 
   validationChecks?: DataConsistencyChecks;
   // Contains the results of data consistency checks based on predefined hypotheses.


### PR DESCRIPTION
## Summary
- extend `JobDescriptionDegreeAnalysis` with deep research and statutes result fields
- append legal research findings to each job's analysis during barrier deep research

## Testing
- `npm run build` in `projects/skillsFirst/agents`


------
https://chatgpt.com/codex/tasks/task_e_687956041090832ea57b8a456273d297