### PR TITLE
Fix web research result URLs

### DIFF
--- a/projects/skillsFirst/agents/src/jobDescriptions/deepResearch/webPageScanner.ts
+++ b/projects/skillsFirst/agents/src/jobDescriptions/deepResearch/webPageScanner.ts
@@ -185,7 +185,17 @@ ${this.memory.researchPlan}
             this.logger.error(`Error processing page ${url} no aiAnalysisObject`);
             continue;
           }
-          aiAnalysisObject.fromUrl = url;
+
+          if (Array.isArray(aiAnalysisObject)) {
+            for (const obj of aiAnalysisObject) {
+              if (obj && typeof obj === "object") {
+                (obj as any).sourceUrl = url;
+              }
+            }
+          } else if (typeof aiAnalysisObject === "object") {
+            (aiAnalysisObject as any).sourceUrl = url;
+          }
+
           this.collectedWebPages.push(aiAnalysisObject);
           this.totalPagesSave++;
         }

--- a/projects/skillsFirst/agents/src/legalResearch/deepResearch/webPageScanner.ts
+++ b/projects/skillsFirst/agents/src/legalResearch/deepResearch/webPageScanner.ts
@@ -175,7 +175,17 @@ export class WebPageScanner extends GetWebPagesBaseAgent {
             this.logger.error(`Error processing page ${url} no aiAnalysisObject`);
             continue;
           }
-          aiAnalysisObject.fromUrl = url;
+
+          if (Array.isArray(aiAnalysisObject)) {
+            for (const obj of aiAnalysisObject) {
+              if (obj && typeof obj === "object") {
+                (obj as any).sourceUrl = url;
+              }
+            }
+          } else if (typeof aiAnalysisObject === "object") {
+            (aiAnalysisObject as any).sourceUrl = url;
+          }
+
           this.collectedWebPages.push(aiAnalysisObject);
           this.totalPagesSave++;
         }


### PR DESCRIPTION
## Summary
- attach `sourceUrl` to each AI analysis result in `webPageScanner`
- apply change to jobDescriptions and legalResearch scanners

## Testing
- `npm run build` in `projects/skillsFirst/agents`

------
https://chatgpt.com/codex/tasks/task_e_687b8bb25bfc832e96f1192bb4301edb