### PR TITLE
Fix OpenAiChat logit bias logic

### DIFF
--- a/agents/src/aiModels/openAiChat.ts
+++ b/agents/src/aiModels/openAiChat.ts
@@ -87,14 +87,16 @@ export class OpenAiChat extends BaseChatModel {
       for (const t of tools) {
         const name = t.type === "function" ? t.function.name : "";
         if (!allowedTools.includes(name)) {
-          const tok = encoding.encode(`"${name}"`)[0];
-          logitBias[tok] = -100;
+          encoding.encode(name).forEach((tok) => {
+            logitBias![tok] = -100;
+          });
         }
       }
       this.logger.debug(
         `Allowed tools: ${JSON.stringify(allowedTools)} logit_bias: ${JSON.stringify(logitBias)}`
       );
     }
+    encoding.free();
 
     // 3. Streaming vs. Non-streaming
     if (streaming) {


### PR DESCRIPTION
## Summary
- handle multitoken tool names when building logit bias in `OpenAiChat.generate`
- free tiktoken encoding after computing the bias

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688006fa1ca4832e880c96a269517ab6