### PR TITLE
Improve tool context for planning

### DIFF
--- a/agents/src/aiModels/openAiChat.ts
+++ b/agents/src/aiModels/openAiChat.ts
@@ -41,10 +41,27 @@ export class OpenAiChat extends BaseChatModel {
     allowedTools?: string[]
   ): Promise<PsBaseModelReturnParameters | undefined> {
     // 1. Convert messages to OpenAI format
-    let formattedMessages = messages.map((msg) => ({
-      role: msg.role as "system" | "developer" | "user" | "assistant",
-      content: msg.message,
-    }));
+    let formattedMessages = messages.map((msg) => {
+      const base: any = {
+        role: msg.role as "system" | "developer" | "user" | "assistant",
+        content: msg.message,
+      };
+      if (msg.name) {
+        base.name = msg.name;
+      }
+      if (msg.toolCall) {
+        base.tool_calls = [
+          {
+            type: "function",
+            function: {
+              name: msg.toolCall.name,
+              arguments: JSON.stringify(msg.toolCall.arguments ?? {}),
+            },
+          },
+        ];
+      }
+      return base;
+    });
 
     // 2. Collapse system message if the model is "small" reasoning
     if (

--- a/agents/src/streamingLlms.d.ts
+++ b/agents/src/streamingLlms.d.ts
@@ -39,4 +39,6 @@ interface PsSimpleChatLog {
 interface PsModelMessage {
   role: string;
   message: string;
+  name?: string;
+  toolCall?: { name: string; arguments: Record<string, unknown> };
 }


### PR DESCRIPTION
## Summary
- allow PsModelMessage to carry tool call info
- preserve name and toolCall while mapping messages in `planStep`
- pass name/toolCall data to OpenAI implementations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880073cbc30832eaa8c672bfdd847f3