### PR TITLE
Support multiple tool calls in agents

### DIFF
--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -134,10 +134,10 @@ interface PsBaseModelReturnParameters {
   cachedInTokens?: number;
   reasoningTokens?: number;
   audioTokens?: number;
-  toolCall?: {
+  toolCalls?: {
     name: string;
     arguments: any;
-  };
+  }[];
 }
 
 // Evaluation configuration for an agent class

--- a/agents/src/aiModels/claudeChat.ts
+++ b/agents/src/aiModels/claudeChat.ts
@@ -154,20 +154,21 @@ export class ClaudeChat extends BaseChatModel {
       if ((response.usage as any).cache_read_input_tokens) {
         tokensIn += (response.usage as any).cache_read_input_tokens * 0.1;
       }
-      let toolCall;
-      const firstBlock = response.content[0];
-      if (firstBlock && firstBlock.type === "tool_use") {
-        toolCall = {
-          name: firstBlock.name ?? "unknown",
-          arguments: firstBlock.input ?? {},
-        };
+      const toolCalls: { name: string; arguments: any }[] = [];
+      for (const block of response.content) {
+        if (block.type === "tool_use") {
+          toolCalls.push({
+            name: block.name ?? "unknown",
+            arguments: block.input ?? {},
+          });
+        }
       }
       return {
         tokensIn: tokensIn,
         tokensOut: tokensOut,
         cachedInTokens: cachedInTokens ?? 0,
         content: this.getTextTypeFromContent(response.content),
-        toolCall,
+        toolCalls,
       };
     }
   }

--- a/agents/src/base/agentModelManager.ts
+++ b/agents/src/base/agentModelManager.ts
@@ -679,7 +679,7 @@ export class PsAiModelManager extends PolicySynthAgentBase {
         )) as PsBaseModelReturnParameters | undefined;
 
         if (results) {
-          const { tokensIn, tokensOut, cachedInTokens, content, toolCall } =
+          const { tokensIn, tokensOut, cachedInTokens, content, toolCalls } =
             results;
 
           await this.saveTokenUsage(
@@ -692,8 +692,8 @@ export class PsAiModelManager extends PolicySynthAgentBase {
             model.dbModelId
           );
 
-          if (toolCall) {
-            return { toolCall };
+          if (toolCalls && toolCalls.length) {
+            return { toolCalls };
           }
           if (options.parseJson) {
             let parsedJson: any;
@@ -849,7 +849,7 @@ export class PsAiModelManager extends PolicySynthAgentBase {
               )) as PsBaseModelReturnParameters | undefined;
 
               if (fallbackResults) {
-                const { tokensIn, tokensOut, cachedInTokens, content, toolCall } =
+                const { tokensIn, tokensOut, cachedInTokens, content, toolCalls } =
                   fallbackResults;
                 await this.saveTokenUsage(
                   fallbackEphemeral.config.prices,
@@ -860,8 +860,8 @@ export class PsAiModelManager extends PolicySynthAgentBase {
                   tokensOut,
                   fallbackEphemeral.dbModelId
                 );
-                if (toolCall) {
-                  return { toolCall };
+                if (toolCalls && toolCalls.length) {
+                  return { toolCalls };
                 }
                 return options.parseJson
                   ? this.parseJsonResponse(content.trim())


### PR DESCRIPTION
## Summary
- handle multiple tool calls returned from models
- gather all tool_calls in OpenAI, Claude and Gemini models
- expose `toolCalls` array in return type
- iterate through tool calls in `agentModelManager` and `PolicySynthAgentTask`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68800c7e1b28832e977c4400271985c9