### PR TITLE
Fix logger usage in callToolStep

### DIFF
--- a/agents/src/base/agentTask.ts
+++ b/agents/src/base/agentTask.ts
@@ -175,7 +175,7 @@ export abstract class PolicySynthAgentTask extends PolicySynthAgent {
     const call = this.messages.at(-1)!.toolCall!;
     const allow = new Set(this.policy());
     if (!allow.has(call.name)) {
-      console.error(
+      this.logger.error(
         `Policy violation: attempted to call disallowed tool ${call.name}`
       );
       const msg = `Tool ${call.name} is not allowed by policy`;


### PR DESCRIPTION
## Summary
- use `this.logger.error` for policy violation errors

## Testing
- `npm run build` in `agents/`

------
https://chatgpt.com/codex/tasks/task_e_68802385cd28832e83c01ee49d31f96b