### PR TITLE
Allow model type override in ephemeral config

### DIFF
--- a/agents/src/agents.d.ts
+++ b/agents/src/agents.d.ts
@@ -42,6 +42,7 @@ interface PsCallModelOptions {
   streamingCallbacks?: Function;
   modelProvider?: string; // e.g. "openai", "anthropic", "google", "azure"
   modelName?: string; // e.g. "gpt-4o", "gemin-2.5-pro", etc.
+  modelType?: import("./aiModelTypes.js").PsAiModelType;
   modelTemperature?: number;
   maxTokensOut?: number;
   modelMaxThinkingTokens?: number;

--- a/agents/src/base/agentModelManager.ts
+++ b/agents/src/base/agentModelManager.ts
@@ -347,7 +347,7 @@ export class PsAiModelManager extends PolicySynthAgentBase {
         options.modelReasoningEffort ?? (this.reasoningEffort as any),
       maxThinkingTokens:
         options.modelMaxThinkingTokens ?? this.maxThinkingTokens,
-      modelType: dbConfig?.type ?? modelType,
+      modelType: options.modelType ?? dbConfig?.type ?? modelType,
       modelSize: dbConfig?.modelSize ?? modelSize,
       timeoutMs: dbConfig?.timeoutMs ?? this.modelCallTimeoutMs,
       prices: dbConfig?.prices ?? fallbackModel.config?.prices ?? ({} as any),


### PR DESCRIPTION
## Summary
- add `modelType` option to `PsCallModelOptions`
- respect `options.modelType` when creating ephemeral models

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b84e266a8832ebab02596f36b8bc8