### PR TITLE
feat(agent-task): allow dynamic reasoning effort

### DIFF
--- a/agents/src/base/agentTask.ts
+++ b/agents/src/base/agentTask.ts
@@ -47,6 +47,15 @@ export abstract class PolicySynthAgentTask extends PolicySynthAgent {
     Promise.all(
       Object.values(this.dirs).map((d) => fsp.mkdir(d, { recursive: true }))
     );
+
+    this.setReasoningEffort(this.reasoningEffort);
+  }
+
+  setReasoningEffort(effort: "low" | "medium" | "high") {
+    this.modelCallOptions.modelReasoningEffort = effort;
+    if (this.modelManager) {
+      this.modelManager.reasoningEffort = effort;
+    }
   }
 
   async *run(


### PR DESCRIPTION
## Summary
- add `setReasoningEffort` to dynamically update reasoning mode
- initialize agent tasks with default reasoning effort

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3b3c35e3c832ea10273ea20d8005b