### PR TITLE
Truncate prompt image data in model override logs

### DIFF
--- a/agents/src/base/agentModelManager.ts
+++ b/agents/src/base/agentModelManager.ts
@@ -298,9 +298,16 @@ export class PsAiModelManager extends PolicySynthAgentBase {
     if (!isOverrideRequested) {
       return undefined;
     } else {
+      const loggingOptions: PsCallModelOptions = {
+        ...options,
+        promptImages: options.promptImages?.map((image) => ({
+          ...image,
+          data: image.data.slice(0, 200),
+        })),
+      };
       this.logger.debug(
         `Ephemeral override requested for ${modelType} ${modelSize} ${JSON.stringify(
-          options,
+          loggingOptions,
           null,
           2
         )}`


### PR DESCRIPTION
## Summary
- Avoid logging full promptImages data by truncating to 200 chars
- Create copy of options before debug logging for ephemeral overrides

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc89c704e4832eb4918bacb04434ce